### PR TITLE
Teach compose to output 'hostname' when present in the compose file

### DIFF
--- a/compose.go
+++ b/compose.go
@@ -399,6 +399,10 @@ func (g *Generator) buildNixContainer(service types.ServiceConfig) (*NixContaine
 		c.ExtraOptions = append(c.ExtraOptions, fmt.Sprintf("--add-host=%s:%s", hostname, ip))
 	}
 
+	if service.Hostname != "" {
+		c.ExtraOptions = append(c.ExtraOptions, "--hostname="+service.Hostname)
+	}
+
 	// https://docs.docker.com/compose/compose-file/05-services/#sysctls
 	// https://docs.docker.com/engine/reference/commandline/run/#sysctl
 	// https://docs.podman.io/en/latest/markdown/podman-run.1.html#sysctl-name-value

--- a/testdata/TestDocker_EnvFilesOnly_out.nix
+++ b/testdata/TestDocker_EnvFilesOnly_out.nix
@@ -81,6 +81,7 @@
     autoStart = false;
     extraOptions = [
       "--health-cmd='curl -f http://localhost/'"
+      "--hostname=sabnzbd"
       "--log-opt=compress=true"
       "--log-opt=max-file=3"
       "--log-opt=max-size=10m"

--- a/testdata/TestDocker_RemoveVolumes_out.nix
+++ b/testdata/TestDocker_RemoveVolumes_out.nix
@@ -89,6 +89,7 @@
     autoStart = false;
     extraOptions = [
       "--health-cmd='curl -f http://localhost/'"
+      "--hostname=sabnzbd"
       "--log-opt=compress=true"
       "--log-opt=max-file=3"
       "--log-opt=max-size=10m"

--- a/testdata/TestDocker_SystemdMount_out.nix
+++ b/testdata/TestDocker_SystemdMount_out.nix
@@ -91,6 +91,7 @@
     autoStart = false;
     extraOptions = [
       "--health-cmd='curl -f http://localhost/'"
+      "--hostname=sabnzbd"
       "--log-opt=compress=true"
       "--log-opt=max-file=3"
       "--log-opt=max-size=10m"

--- a/testdata/TestDocker_WithProject_out.nix
+++ b/testdata/TestDocker_WithProject_out.nix
@@ -89,6 +89,7 @@
     autoStart = false;
     extraOptions = [
       "--health-cmd='curl -f http://localhost/'"
+      "--hostname=sabnzbd"
       "--log-opt=compress=true"
       "--log-opt=max-file=3"
       "--log-opt=max-size=10m"

--- a/testdata/TestDocker_out.nix
+++ b/testdata/TestDocker_out.nix
@@ -87,6 +87,7 @@
     log-driver = "journald";
     extraOptions = [
       "--health-cmd='curl -f http://localhost/'"
+      "--hostname=sabnzbd"
       "--log-opt=compress=true"
       "--log-opt=max-file=3"
       "--log-opt=max-size=10m"

--- a/testdata/TestPodman_WithProject_out.nix
+++ b/testdata/TestPodman_WithProject_out.nix
@@ -88,6 +88,7 @@
     autoStart = false;
     extraOptions = [
       "--health-cmd='curl -f http://localhost/'"
+      "--hostname=sabnzbd"
       "--log-opt=compress=true"
       "--log-opt=max-file=3"
       "--log-opt=max-size=10m"

--- a/testdata/TestPodman_out.nix
+++ b/testdata/TestPodman_out.nix
@@ -86,6 +86,7 @@
     log-driver = "journald";
     extraOptions = [
       "--health-cmd='curl -f http://localhost/'"
+      "--hostname=sabnzbd"
       "--log-opt=compress=true"
       "--log-opt=max-file=3"
       "--log-opt=max-size=10m"

--- a/testdata/docker-compose.yml
+++ b/testdata/docker-compose.yml
@@ -3,6 +3,7 @@ name: "myproject"
 services:
   sabnzbd:
     image: lscr.io/linuxserver/sabnzbd
+    hostname: sabnzbd
     environment:
       PUID: ${PUID}
       PGID: ${PGID}


### PR DESCRIPTION
Fixes #6 

This is support for this natively on oci-containers NixOs/nixpkgs#258299, however it's still on unstable