### PR TITLE
fix: do not wrap --health-cmd in quotes

### DIFF
--- a/compose.go
+++ b/compose.go
@@ -516,7 +516,7 @@ func (g *Generator) buildNixContainer(service types.ServiceConfig, networkMap ma
 				cmd = strings.ReplaceAll(cmd, `"`, `\"`)
 				cmd = strings.ReplaceAll(cmd, "${", `\${`)
 
-				c.ExtraOptions = append(c.ExtraOptions, fmt.Sprintf("--health-cmd='%s'", cmd))
+				c.ExtraOptions = append(c.ExtraOptions, fmt.Sprintf("--health-cmd=%s", cmd))
 			}
 			if timeout := healthCheck.Timeout; timeout != nil {
 				c.ExtraOptions = append(c.ExtraOptions, fmt.Sprintf("--health-timeout=%v", *timeout))

--- a/nixos-test/docker-compose.nix
+++ b/nixos-test/docker-compose.nix
@@ -1,4 +1,4 @@
-# Auto-generated using compose2nix v0.1.9.
+# Auto-generated using compose2nix v0.2.0-pre.
 { pkgs, lib, ... }:
 
 {
@@ -69,6 +69,7 @@
     ];
     log-driver = "journald";
     extraOptions = [
+      "--health-cmd=echo abc && true"
       "--ip=192.168.8.20"
       "--network-alias=service-b"
       "--network=myproject_something"

--- a/nixos-test/docker-compose.yml
+++ b/nixos-test/docker-compose.yml
@@ -29,6 +29,8 @@ services:
       - "compose2nix.systemd.service.RuntimeMaxSec=360"
     depends_on:
       - service-a
+    healthcheck:
+      test: echo abc && true
     networks:
       something:
         ipv4_address: 192.168.8.20

--- a/nixos-test/podman-compose.nix
+++ b/nixos-test/podman-compose.nix
@@ -1,4 +1,4 @@
-# Auto-generated using compose2nix v0.1.9.
+# Auto-generated using compose2nix v0.2.0-pre.
 { pkgs, lib, ... }:
 
 {
@@ -71,6 +71,7 @@
     ];
     log-driver = "journald";
     extraOptions = [
+      "--health-cmd=echo abc && true"
       "--ip=192.168.8.20"
       "--network-alias=service-b"
       "--network=myproject_something"

--- a/nixos-test/test.nix
+++ b/nixos-test/test.nix
@@ -15,6 +15,7 @@ let
     virtualisation.graphics = false;
     virtualisation.oci-containers.containers."myproject-service-a".imageFile = nginxImage;
     virtualisation.oci-containers.containers."service-b".imageFile = nginxImage;
+    environment.systemPackages = [ pkgs.jq ];
     system.stateVersion = "23.05";
   };
 in
@@ -51,5 +52,8 @@ in
       # Wait for container services.
       m.wait_for_unit(f"{runtime}-myproject-service-a.service")
       m.wait_for_unit(f"{runtime}-service-b.service")
+
+      # Wait until the health check succeeds.
+      m.wait_until_succeeds(f"{runtime} inspect service-b | jq .[0].State.Health.Status | grep healthy", timeout=30)
   '';
 }

--- a/testdata/TestBasic.docker.nix
+++ b/testdata/TestBasic.docker.nix
@@ -35,7 +35,7 @@
       "--cpu-quota=1.5"
       "--cpus=1"
       "--dns=1.1.1.1"
-      "--health-cmd='curl -f http://localhost/\${POTATO}'"
+      "--health-cmd=curl -f http://localhost/\${POTATO}"
       "--log-opt=compress=true"
       "--log-opt=max-file=3"
       "--log-opt=max-size=10m"
@@ -91,7 +91,7 @@
     };
     log-driver = "journald";
     extraOptions = [
-      "--health-cmd='curl -f http://localhost/'"
+      "--health-cmd=curl -f http://localhost/"
       "--hostname=sabnzbd"
       "--log-opt=compress=true"
       "--log-opt=max-file=3"
@@ -143,7 +143,7 @@
     user = "1000:1000";
     log-driver = "journald";
     extraOptions = [
-      "--health-cmd='[\"curl\",\"-f\",\"http://localhost\"]'"
+      "--health-cmd=[\"curl\",\"-f\",\"http://localhost\"]"
       "--health-interval=1m30s"
       "--health-retries=3"
       "--health-start-period=40s"

--- a/testdata/TestBasic.podman.nix
+++ b/testdata/TestBasic.podman.nix
@@ -40,7 +40,7 @@
       "--cpu-quota=1.5"
       "--cpus=1"
       "--dns=1.1.1.1"
-      "--health-cmd='curl -f http://localhost/\${POTATO}'"
+      "--health-cmd=curl -f http://localhost/\${POTATO}"
       "--log-opt=compress=true"
       "--log-opt=max-file=3"
       "--log-opt=max-size=10m"
@@ -94,7 +94,7 @@
     };
     log-driver = "journald";
     extraOptions = [
-      "--health-cmd='curl -f http://localhost/'"
+      "--health-cmd=curl -f http://localhost/"
       "--hostname=sabnzbd"
       "--log-opt=compress=true"
       "--log-opt=max-file=3"
@@ -143,7 +143,7 @@
     user = "1000:1000";
     log-driver = "journald";
     extraOptions = [
-      "--health-cmd='[\"curl\",\"-f\",\"http://localhost\"]'"
+      "--health-cmd=[\"curl\",\"-f\",\"http://localhost\"]"
       "--health-interval=1m30s"
       "--health-retries=3"
       "--health-start-interval=5s"

--- a/testdata/TestEnvFilesOnly.docker.nix
+++ b/testdata/TestEnvFilesOnly.docker.nix
@@ -34,7 +34,7 @@
       "--cpu-quota=1.5"
       "--cpus=1"
       "--dns=1.1.1.1"
-      "--health-cmd='curl -f http://localhost/\${POTATO}'"
+      "--health-cmd=curl -f http://localhost/\${POTATO}"
       "--log-opt=compress=true"
       "--log-opt=max-file=3"
       "--log-opt=max-size=10m"
@@ -85,7 +85,7 @@
     log-driver = "journald";
     autoStart = false;
     extraOptions = [
-      "--health-cmd='curl -f http://localhost/'"
+      "--health-cmd=curl -f http://localhost/"
       "--hostname=sabnzbd"
       "--log-opt=compress=true"
       "--log-opt=max-file=3"
@@ -133,7 +133,7 @@
     log-driver = "journald";
     autoStart = false;
     extraOptions = [
-      "--health-cmd='[\"curl\",\"-f\",\"http://localhost\"]'"
+      "--health-cmd=[\"curl\",\"-f\",\"http://localhost\"]"
       "--health-interval=1m30s"
       "--health-retries=3"
       "--health-start-period=40s"

--- a/testdata/TestEnvFilesOnly.podman.nix
+++ b/testdata/TestEnvFilesOnly.podman.nix
@@ -39,7 +39,7 @@
       "--cpu-quota=1.5"
       "--cpus=1"
       "--dns=1.1.1.1"
-      "--health-cmd='curl -f http://localhost/\${POTATO}'"
+      "--health-cmd=curl -f http://localhost/\${POTATO}"
       "--log-opt=compress=true"
       "--log-opt=max-file=3"
       "--log-opt=max-size=10m"
@@ -88,7 +88,7 @@
     log-driver = "journald";
     autoStart = false;
     extraOptions = [
-      "--health-cmd='curl -f http://localhost/'"
+      "--health-cmd=curl -f http://localhost/"
       "--hostname=sabnzbd"
       "--log-opt=compress=true"
       "--log-opt=max-file=3"
@@ -133,7 +133,7 @@
     log-driver = "journald";
     autoStart = false;
     extraOptions = [
-      "--health-cmd='[\"curl\",\"-f\",\"http://localhost\"]'"
+      "--health-cmd=[\"curl\",\"-f\",\"http://localhost\"]"
       "--health-interval=1m30s"
       "--health-retries=3"
       "--health-start-interval=5s"

--- a/testdata/TestNoWriteNixSetup.docker.nix
+++ b/testdata/TestNoWriteNixSetup.docker.nix
@@ -30,7 +30,7 @@
       "--cpu-quota=1.5"
       "--cpus=1"
       "--dns=1.1.1.1"
-      "--health-cmd='curl -f http://localhost/\${POTATO}'"
+      "--health-cmd=curl -f http://localhost/\${POTATO}"
       "--log-opt=compress=true"
       "--log-opt=max-file=3"
       "--log-opt=max-size=10m"
@@ -87,7 +87,7 @@
     log-driver = "journald";
     autoStart = false;
     extraOptions = [
-      "--health-cmd='curl -f http://localhost/'"
+      "--health-cmd=curl -f http://localhost/"
       "--hostname=sabnzbd"
       "--log-opt=compress=true"
       "--log-opt=max-file=3"
@@ -140,7 +140,7 @@
     log-driver = "journald";
     autoStart = false;
     extraOptions = [
-      "--health-cmd='[\"curl\",\"-f\",\"http://localhost\"]'"
+      "--health-cmd=[\"curl\",\"-f\",\"http://localhost\"]"
       "--health-interval=1m30s"
       "--health-retries=3"
       "--health-start-period=40s"

--- a/testdata/TestNoWriteNixSetup.podman.nix
+++ b/testdata/TestNoWriteNixSetup.podman.nix
@@ -30,7 +30,7 @@
       "--cpu-quota=1.5"
       "--cpus=1"
       "--dns=1.1.1.1"
-      "--health-cmd='curl -f http://localhost/\${POTATO}'"
+      "--health-cmd=curl -f http://localhost/\${POTATO}"
       "--log-opt=compress=true"
       "--log-opt=max-file=3"
       "--log-opt=max-size=10m"
@@ -85,7 +85,7 @@
     log-driver = "journald";
     autoStart = false;
     extraOptions = [
-      "--health-cmd='curl -f http://localhost/'"
+      "--health-cmd=curl -f http://localhost/"
       "--hostname=sabnzbd"
       "--log-opt=compress=true"
       "--log-opt=max-file=3"
@@ -135,7 +135,7 @@
     log-driver = "journald";
     autoStart = false;
     extraOptions = [
-      "--health-cmd='[\"curl\",\"-f\",\"http://localhost\"]'"
+      "--health-cmd=[\"curl\",\"-f\",\"http://localhost\"]"
       "--health-interval=1m30s"
       "--health-retries=3"
       "--health-start-interval=5s"

--- a/testdata/TestOverrideSystemdStopTimeout.docker.nix
+++ b/testdata/TestOverrideSystemdStopTimeout.docker.nix
@@ -36,7 +36,7 @@
       "--cpu-quota=1.5"
       "--cpus=1"
       "--dns=1.1.1.1"
-      "--health-cmd='curl -f http://localhost/\${POTATO}'"
+      "--health-cmd=curl -f http://localhost/\${POTATO}"
       "--log-opt=compress=true"
       "--log-opt=max-file=3"
       "--log-opt=max-size=10m"
@@ -94,7 +94,7 @@
     log-driver = "journald";
     autoStart = false;
     extraOptions = [
-      "--health-cmd='curl -f http://localhost/'"
+      "--health-cmd=curl -f http://localhost/"
       "--hostname=sabnzbd"
       "--log-opt=compress=true"
       "--log-opt=max-file=3"
@@ -148,7 +148,7 @@
     log-driver = "journald";
     autoStart = false;
     extraOptions = [
-      "--health-cmd='[\"curl\",\"-f\",\"http://localhost\"]'"
+      "--health-cmd=[\"curl\",\"-f\",\"http://localhost\"]"
       "--health-interval=1m30s"
       "--health-retries=3"
       "--health-start-period=40s"

--- a/testdata/TestOverrideSystemdStopTimeout.podman.nix
+++ b/testdata/TestOverrideSystemdStopTimeout.podman.nix
@@ -41,7 +41,7 @@
       "--cpu-quota=1.5"
       "--cpus=1"
       "--dns=1.1.1.1"
-      "--health-cmd='curl -f http://localhost/\${POTATO}'"
+      "--health-cmd=curl -f http://localhost/\${POTATO}"
       "--log-opt=compress=true"
       "--log-opt=max-file=3"
       "--log-opt=max-size=10m"
@@ -97,7 +97,7 @@
     log-driver = "journald";
     autoStart = false;
     extraOptions = [
-      "--health-cmd='curl -f http://localhost/'"
+      "--health-cmd=curl -f http://localhost/"
       "--hostname=sabnzbd"
       "--log-opt=compress=true"
       "--log-opt=max-file=3"
@@ -148,7 +148,7 @@
     log-driver = "journald";
     autoStart = false;
     extraOptions = [
-      "--health-cmd='[\"curl\",\"-f\",\"http://localhost\"]'"
+      "--health-cmd=[\"curl\",\"-f\",\"http://localhost\"]"
       "--health-interval=1m30s"
       "--health-retries=3"
       "--health-start-interval=5s"

--- a/testdata/TestProject.docker.nix
+++ b/testdata/TestProject.docker.nix
@@ -36,7 +36,7 @@
       "--cpu-quota=1.5"
       "--cpus=1"
       "--dns=1.1.1.1"
-      "--health-cmd='curl -f http://localhost/\${POTATO}'"
+      "--health-cmd=curl -f http://localhost/\${POTATO}"
       "--log-opt=compress=true"
       "--log-opt=max-file=3"
       "--log-opt=max-size=10m"
@@ -93,7 +93,7 @@
     log-driver = "journald";
     autoStart = false;
     extraOptions = [
-      "--health-cmd='curl -f http://localhost/'"
+      "--health-cmd=curl -f http://localhost/"
       "--hostname=sabnzbd"
       "--log-opt=compress=true"
       "--log-opt=max-file=3"
@@ -146,7 +146,7 @@
     log-driver = "journald";
     autoStart = false;
     extraOptions = [
-      "--health-cmd='[\"curl\",\"-f\",\"http://localhost\"]'"
+      "--health-cmd=[\"curl\",\"-f\",\"http://localhost\"]"
       "--health-interval=1m30s"
       "--health-retries=3"
       "--health-start-period=40s"

--- a/testdata/TestProject.podman.nix
+++ b/testdata/TestProject.podman.nix
@@ -41,7 +41,7 @@
       "--cpu-quota=1.5"
       "--cpus=1"
       "--dns=1.1.1.1"
-      "--health-cmd='curl -f http://localhost/\${POTATO}'"
+      "--health-cmd=curl -f http://localhost/\${POTATO}"
       "--log-opt=compress=true"
       "--log-opt=max-file=3"
       "--log-opt=max-size=10m"
@@ -96,7 +96,7 @@
     log-driver = "journald";
     autoStart = false;
     extraOptions = [
-      "--health-cmd='curl -f http://localhost/'"
+      "--health-cmd=curl -f http://localhost/"
       "--hostname=sabnzbd"
       "--log-opt=compress=true"
       "--log-opt=max-file=3"
@@ -146,7 +146,7 @@
     log-driver = "journald";
     autoStart = false;
     extraOptions = [
-      "--health-cmd='[\"curl\",\"-f\",\"http://localhost\"]'"
+      "--health-cmd=[\"curl\",\"-f\",\"http://localhost\"]"
       "--health-interval=1m30s"
       "--health-retries=3"
       "--health-start-interval=5s"

--- a/testdata/TestRemoveVolumes.docker.nix
+++ b/testdata/TestRemoveVolumes.docker.nix
@@ -36,7 +36,7 @@
       "--cpu-quota=1.5"
       "--cpus=1"
       "--dns=1.1.1.1"
-      "--health-cmd='curl -f http://localhost/\${POTATO}'"
+      "--health-cmd=curl -f http://localhost/\${POTATO}"
       "--log-opt=compress=true"
       "--log-opt=max-file=3"
       "--log-opt=max-size=10m"
@@ -93,7 +93,7 @@
     log-driver = "journald";
     autoStart = false;
     extraOptions = [
-      "--health-cmd='curl -f http://localhost/'"
+      "--health-cmd=curl -f http://localhost/"
       "--hostname=sabnzbd"
       "--log-opt=compress=true"
       "--log-opt=max-file=3"
@@ -146,7 +146,7 @@
     log-driver = "journald";
     autoStart = false;
     extraOptions = [
-      "--health-cmd='[\"curl\",\"-f\",\"http://localhost\"]'"
+      "--health-cmd=[\"curl\",\"-f\",\"http://localhost\"]"
       "--health-interval=1m30s"
       "--health-retries=3"
       "--health-start-period=40s"

--- a/testdata/TestRemoveVolumes.podman.nix
+++ b/testdata/TestRemoveVolumes.podman.nix
@@ -41,7 +41,7 @@
       "--cpu-quota=1.5"
       "--cpus=1"
       "--dns=1.1.1.1"
-      "--health-cmd='curl -f http://localhost/\${POTATO}'"
+      "--health-cmd=curl -f http://localhost/\${POTATO}"
       "--log-opt=compress=true"
       "--log-opt=max-file=3"
       "--log-opt=max-size=10m"
@@ -96,7 +96,7 @@
     log-driver = "journald";
     autoStart = false;
     extraOptions = [
-      "--health-cmd='curl -f http://localhost/'"
+      "--health-cmd=curl -f http://localhost/"
       "--hostname=sabnzbd"
       "--log-opt=compress=true"
       "--log-opt=max-file=3"
@@ -146,7 +146,7 @@
     log-driver = "journald";
     autoStart = false;
     extraOptions = [
-      "--health-cmd='[\"curl\",\"-f\",\"http://localhost\"]'"
+      "--health-cmd=[\"curl\",\"-f\",\"http://localhost\"]"
       "--health-interval=1m30s"
       "--health-retries=3"
       "--health-start-interval=5s"

--- a/testdata/TestSystemdMount.docker.nix
+++ b/testdata/TestSystemdMount.docker.nix
@@ -36,7 +36,7 @@
       "--cpu-quota=1.5"
       "--cpus=1"
       "--dns=1.1.1.1"
-      "--health-cmd='curl -f http://localhost/\${POTATO}'"
+      "--health-cmd=curl -f http://localhost/\${POTATO}"
       "--log-opt=compress=true"
       "--log-opt=max-file=3"
       "--log-opt=max-size=10m"
@@ -96,7 +96,7 @@
     log-driver = "journald";
     autoStart = false;
     extraOptions = [
-      "--health-cmd='curl -f http://localhost/'"
+      "--health-cmd=curl -f http://localhost/"
       "--hostname=sabnzbd"
       "--log-opt=compress=true"
       "--log-opt=max-file=3"
@@ -152,7 +152,7 @@
     log-driver = "journald";
     autoStart = false;
     extraOptions = [
-      "--health-cmd='[\"curl\",\"-f\",\"http://localhost\"]'"
+      "--health-cmd=[\"curl\",\"-f\",\"http://localhost\"]"
       "--health-interval=1m30s"
       "--health-retries=3"
       "--health-start-period=40s"

--- a/testdata/TestSystemdMount.podman.nix
+++ b/testdata/TestSystemdMount.podman.nix
@@ -41,7 +41,7 @@
       "--cpu-quota=1.5"
       "--cpus=1"
       "--dns=1.1.1.1"
-      "--health-cmd='curl -f http://localhost/\${POTATO}'"
+      "--health-cmd=curl -f http://localhost/\${POTATO}"
       "--log-opt=compress=true"
       "--log-opt=max-file=3"
       "--log-opt=max-size=10m"
@@ -99,7 +99,7 @@
     log-driver = "journald";
     autoStart = false;
     extraOptions = [
-      "--health-cmd='curl -f http://localhost/'"
+      "--health-cmd=curl -f http://localhost/"
       "--hostname=sabnzbd"
       "--log-opt=compress=true"
       "--log-opt=max-file=3"
@@ -152,7 +152,7 @@
     log-driver = "journald";
     autoStart = false;
     extraOptions = [
-      "--health-cmd='[\"curl\",\"-f\",\"http://localhost\"]'"
+      "--health-cmd=[\"curl\",\"-f\",\"http://localhost\"]"
       "--health-interval=1m30s"
       "--health-retries=3"
       "--health-start-interval=5s"

--- a/testdata/TestUpheldBy.docker.nix
+++ b/testdata/TestUpheldBy.docker.nix
@@ -36,7 +36,7 @@
       "--cpu-quota=1.5"
       "--cpus=1"
       "--dns=1.1.1.1"
-      "--health-cmd='curl -f http://localhost/\${POTATO}'"
+      "--health-cmd=curl -f http://localhost/\${POTATO}"
       "--log-opt=compress=true"
       "--log-opt=max-file=3"
       "--log-opt=max-size=10m"
@@ -96,7 +96,7 @@
     log-driver = "journald";
     autoStart = false;
     extraOptions = [
-      "--health-cmd='curl -f http://localhost/'"
+      "--health-cmd=curl -f http://localhost/"
       "--hostname=sabnzbd"
       "--log-opt=compress=true"
       "--log-opt=max-file=3"
@@ -149,7 +149,7 @@
     log-driver = "journald";
     autoStart = false;
     extraOptions = [
-      "--health-cmd='[\"curl\",\"-f\",\"http://localhost\"]'"
+      "--health-cmd=[\"curl\",\"-f\",\"http://localhost\"]"
       "--health-interval=1m30s"
       "--health-retries=3"
       "--health-start-period=40s"

--- a/testdata/TestUpheldBy.podman.nix
+++ b/testdata/TestUpheldBy.podman.nix
@@ -41,7 +41,7 @@
       "--cpu-quota=1.5"
       "--cpus=1"
       "--dns=1.1.1.1"
-      "--health-cmd='curl -f http://localhost/\${POTATO}'"
+      "--health-cmd=curl -f http://localhost/\${POTATO}"
       "--log-opt=compress=true"
       "--log-opt=max-file=3"
       "--log-opt=max-size=10m"
@@ -99,7 +99,7 @@
     log-driver = "journald";
     autoStart = false;
     extraOptions = [
-      "--health-cmd='curl -f http://localhost/'"
+      "--health-cmd=curl -f http://localhost/"
       "--hostname=sabnzbd"
       "--log-opt=compress=true"
       "--log-opt=max-file=3"
@@ -149,7 +149,7 @@
     log-driver = "journald";
     autoStart = false;
     extraOptions = [
-      "--health-cmd='[\"curl\",\"-f\",\"http://localhost\"]'"
+      "--health-cmd=[\"curl\",\"-f\",\"http://localhost\"]"
       "--health-interval=1m30s"
       "--health-retries=3"
       "--health-start-interval=5s"


### PR DESCRIPTION
We cannot wrap the health command with single quotes because Nix calls `escapeShellArg` under the hood on each entry in the `ExtraOptions` array.

This results in us passing in the single-quote wrapped command as-is - i.e., including single quotes - to the runtime, which causes the entire quote-enclosed string to be interpreted as an *executable* rather than a shell command.

I have also added a simple health check to the integration test.

Fixes #22.