### PR TITLE
fix: set override correctly for systemd services

### DIFF
--- a/nixos-test/docker-compose.nix
+++ b/nixos-test/docker-compose.nix
@@ -1,4 +1,4 @@
-# Auto-generated using compose2nix v0.2.3-pre.
+# Auto-generated using compose2nix v0.2.4-pre.
 { pkgs, lib, ... }:
 
 {
@@ -20,7 +20,7 @@
   };
   systemd.services."docker-myproject-no-restart" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "no";
+      Restart = lib.mkOverride 90 "no";
     };
     after = [
       "docker-network-myproject_default.service"
@@ -59,11 +59,11 @@
   };
   systemd.services."docker-myproject-service-a" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "no";
-      RestartMaxDelaySec = lib.mkOverride 500 "1m";
-      RestartSec = lib.mkOverride 500 "100ms";
-      RestartSteps = lib.mkOverride 500 9;
-      RuntimeMaxSec = lib.mkOverride 500 360;
+      Restart = lib.mkOverride 90 "no";
+      RestartMaxDelaySec = lib.mkOverride 90 "1m";
+      RestartSec = lib.mkOverride 90 "100ms";
+      RestartSteps = lib.mkOverride 90 9;
+      RuntimeMaxSec = lib.mkOverride 90 360;
     };
     unitConfig = {
       Description = lib.mkOverride 500 "This is the service-a container!";
@@ -113,8 +113,8 @@
   };
   systemd.services."docker-service-b" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "on-failure";
-      RuntimeMaxSec = lib.mkOverride 500 360;
+      Restart = lib.mkOverride 90 "on-failure";
+      RuntimeMaxSec = lib.mkOverride 90 360;
     };
     startLimitBurst = 3;
     unitConfig = {

--- a/nixos-test/podman-compose.nix
+++ b/nixos-test/podman-compose.nix
@@ -1,4 +1,4 @@
-# Auto-generated using compose2nix v0.2.3-pre.
+# Auto-generated using compose2nix v0.2.4-pre.
 { pkgs, lib, ... }:
 
 {
@@ -25,7 +25,7 @@
   };
   systemd.services."podman-myproject-no-restart" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "no";
+      Restart = lib.mkOverride 90 "no";
     };
     after = [
       "podman-network-myproject_default.service"
@@ -64,8 +64,8 @@
   };
   systemd.services."podman-myproject-service-a" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "no";
-      RuntimeMaxSec = lib.mkOverride 500 360;
+      Restart = lib.mkOverride 90 "no";
+      RuntimeMaxSec = lib.mkOverride 90 360;
     };
     unitConfig = {
       Description = lib.mkOverride 500 "This is the service-a container!";
@@ -115,8 +115,8 @@
   };
   systemd.services."podman-service-b" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "on-failure";
-      RuntimeMaxSec = lib.mkOverride 500 360;
+      Restart = lib.mkOverride 90 "on-failure";
+      RuntimeMaxSec = lib.mkOverride 90 360;
     };
     startLimitBurst = 3;
     unitConfig = {

--- a/nixos-test/test.nix
+++ b/nixos-test/test.nix
@@ -23,22 +23,45 @@ in
 {
   name = "basic";
   nodes = {
-    docker = { pkgs, ... }: {
+    docker = { pkgs, lib, ... }: {
       imports = [
         ./docker-compose.nix
       ];
+      # Override restart value and ensure it takes effect.
+      systemd.services."docker-service-b" = {
+        serviceConfig = {
+          Restart = lib.mkForce "on-success";
+        };
+      };
     } // common;
-    podman = { pkgs, ... }: {
+    podman = { pkgs, lib, ... }: {
       imports = [
         ./podman-compose.nix
       ];
+      # Override restart value and ensure it takes effect.
+      systemd.services."podman-service-b" = {
+        serviceConfig = {
+          Restart = lib.mkForce "on-success";
+        };
+      };
     } // common;
   };
   # https://nixos.org/manual/nixos/stable/index.html#sec-nixos-tests
   testScript = ''
+    import re
+
     d = {"docker": docker, "podman": podman}
 
     start_all()
+
+    def assert_service_value(service: str, key: str, want: str) -> None:
+      out = m.succeed(f"systemctl show {service}.service")
+      pat = r"\b%s=(\S+)$" % key
+      match = re.search(pat, out, flags=re.M)
+      if not match:
+        raise Exception(f"value for \"{key}\" not found in output using pattern \"{pat}\":\n{out}")
+      got = match.group(1)
+      assert got == want, f"got: \"{key} = {got}\", want: \"{key} = {want}\""
 
     # Create required directories for Docker Compose volumes and bind mounts.
     for runtime, m in d.items():
@@ -58,6 +81,12 @@ in
 
       # Wait until the health check succeeds.
       m.wait_until_succeeds(f"{runtime} inspect service-b | jq .[0].State.Health.Status | grep healthy", timeout=30)
+
+      # Ensure that service-b has its restart setting overriden by this test.
+      assert_service_value(f"{runtime}-service-b", "Restart", "on-success")
+
+      # Ensure that no-restart service has restart disabled.
+      assert_service_value(f"{runtime}-myproject-no-restart", "Restart", "no")
 
       # Stop the root unit.
       m.systemctl(f"stop {runtime}-compose-myproject-root.target")

--- a/templates/container.nix.tmpl
+++ b/templates/container.nix.tmpl
@@ -77,7 +77,7 @@ systemd.services."{{.Runtime}}-{{.Name}}" = {
   {{- if .SystemdConfig.Service}}
   serviceConfig = {
     {{- range $k, $v := .SystemdConfig.Service.Options}}
-    {{$k}} = lib.mkOverride 500 {{toNixValue $v}};
+    {{$k}} = lib.mkOverride 90 {{toNixValue $v}};
     {{- end}}
   };
   {{- end}}

--- a/testdata/TestAutoStart.docker.nix
+++ b/testdata/TestAutoStart.docker.nix
@@ -22,10 +22,10 @@
   };
   systemd.services."docker-test-auto-start" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "always";
-      RestartMaxDelaySec = lib.mkOverride 500 "1m";
-      RestartSec = lib.mkOverride 500 "100ms";
-      RestartSteps = lib.mkOverride 500 9;
+      Restart = lib.mkOverride 90 "always";
+      RestartMaxDelaySec = lib.mkOverride 90 "1m";
+      RestartSec = lib.mkOverride 90 "100ms";
+      RestartSteps = lib.mkOverride 90 9;
     };
     after = [
       "docker-network-test_default.service"
@@ -51,10 +51,10 @@
   };
   systemd.services."docker-test-default-no-auto-start" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "always";
-      RestartMaxDelaySec = lib.mkOverride 500 "1m";
-      RestartSec = lib.mkOverride 500 "100ms";
-      RestartSteps = lib.mkOverride 500 9;
+      Restart = lib.mkOverride 90 "always";
+      RestartMaxDelaySec = lib.mkOverride 90 "1m";
+      RestartSec = lib.mkOverride 90 "100ms";
+      RestartSteps = lib.mkOverride 90 9;
     };
     after = [
       "docker-network-test_default.service"
@@ -77,10 +77,10 @@
   };
   systemd.services."docker-test-no-auto-start" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "always";
-      RestartMaxDelaySec = lib.mkOverride 500 "1m";
-      RestartSec = lib.mkOverride 500 "100ms";
-      RestartSteps = lib.mkOverride 500 9;
+      Restart = lib.mkOverride 90 "always";
+      RestartMaxDelaySec = lib.mkOverride 90 "1m";
+      RestartSec = lib.mkOverride 90 "100ms";
+      RestartSteps = lib.mkOverride 90 9;
     };
     after = [
       "docker-network-test_default.service"

--- a/testdata/TestAutoStart.podman.nix
+++ b/testdata/TestAutoStart.podman.nix
@@ -27,7 +27,7 @@
   };
   systemd.services."podman-test-auto-start" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "always";
+      Restart = lib.mkOverride 90 "always";
     };
     after = [
       "podman-network-test_default.service"
@@ -53,7 +53,7 @@
   };
   systemd.services."podman-test-default-no-auto-start" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "always";
+      Restart = lib.mkOverride 90 "always";
     };
     after = [
       "podman-network-test_default.service"
@@ -76,7 +76,7 @@
   };
   systemd.services."podman-test-no-auto-start" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "always";
+      Restart = lib.mkOverride 90 "always";
     };
     after = [
       "podman-network-test_default.service"

--- a/testdata/TestBasic.docker.nix
+++ b/testdata/TestBasic.docker.nix
@@ -46,10 +46,10 @@
   };
   systemd.services."docker-jellyseerr" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "on-failure";
-      RestartMaxDelaySec = lib.mkOverride 500 "1m";
-      RestartSec = lib.mkOverride 500 "100ms";
-      RestartSteps = lib.mkOverride 500 9;
+      Restart = lib.mkOverride 90 "on-failure";
+      RestartMaxDelaySec = lib.mkOverride 90 "1m";
+      RestartSec = lib.mkOverride 90 "100ms";
+      RestartSteps = lib.mkOverride 90 9;
     };
     startLimitBurst = 3;
     unitConfig = {
@@ -104,11 +104,11 @@
   };
   systemd.services."docker-myproject-sabnzbd" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "always";
-      RestartMaxDelaySec = lib.mkOverride 500 "1m";
-      RestartSec = lib.mkOverride 500 "100ms";
-      RestartSteps = lib.mkOverride 500 9;
-      RuntimeMaxSec = lib.mkOverride 500 10;
+      Restart = lib.mkOverride 90 "always";
+      RestartMaxDelaySec = lib.mkOverride 90 "1m";
+      RestartSec = lib.mkOverride 90 "100ms";
+      RestartSteps = lib.mkOverride 90 9;
+      RuntimeMaxSec = lib.mkOverride 90 10;
     };
     unitConfig = {
       Description = lib.mkOverride 500 "This is the sabnzbd container!";
@@ -158,10 +158,10 @@
   };
   systemd.services."docker-photoprism-mariadb" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "always";
-      RestartMaxDelaySec = lib.mkOverride 500 "1m";
-      RestartSec = lib.mkOverride 500 "100ms";
-      RestartSteps = lib.mkOverride 500 9;
+      Restart = lib.mkOverride 90 "always";
+      RestartMaxDelaySec = lib.mkOverride 90 "1m";
+      RestartSec = lib.mkOverride 90 "100ms";
+      RestartSteps = lib.mkOverride 90 9;
     };
     startLimitBurst = 10;
     unitConfig = {
@@ -238,7 +238,7 @@
   };
   systemd.services."docker-torrent-client" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "on-failure";
+      Restart = lib.mkOverride 90 "on-failure";
     };
     startLimitBurst = 3;
     unitConfig = {
@@ -290,7 +290,7 @@
   };
   systemd.services."docker-traefik" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "no";
+      Restart = lib.mkOverride 90 "no";
     };
     unitConfig = {
       AllowIsolate = lib.mkOverride 500 true;

--- a/testdata/TestBasic.podman.nix
+++ b/testdata/TestBasic.podman.nix
@@ -51,8 +51,8 @@
   };
   systemd.services."podman-jellyseerr" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "on-failure";
-      RestartSec = lib.mkOverride 500 "5s";
+      Restart = lib.mkOverride 90 "on-failure";
+      RestartSec = lib.mkOverride 90 "5s";
     };
     startLimitBurst = 3;
     unitConfig = {
@@ -107,8 +107,8 @@
   };
   systemd.services."podman-myproject-sabnzbd" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "always";
-      RuntimeMaxSec = lib.mkOverride 500 10;
+      Restart = lib.mkOverride 90 "always";
+      RuntimeMaxSec = lib.mkOverride 90 10;
     };
     unitConfig = {
       Description = lib.mkOverride 500 "This is the sabnzbd container!";
@@ -159,8 +159,8 @@
   };
   systemd.services."podman-photoprism-mariadb" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "always";
-      RestartSec = lib.mkOverride 500 "3m0s";
+      Restart = lib.mkOverride 90 "always";
+      RestartSec = lib.mkOverride 90 "3m0s";
     };
     startLimitBurst = 10;
     unitConfig = {
@@ -236,7 +236,7 @@
   };
   systemd.services."podman-torrent-client" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "on-failure";
+      Restart = lib.mkOverride 90 "on-failure";
     };
     startLimitBurst = 3;
     unitConfig = {
@@ -288,7 +288,7 @@
   };
   systemd.services."podman-traefik" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "no";
+      Restart = lib.mkOverride 90 "no";
     };
     unitConfig = {
       AllowIsolate = lib.mkOverride 500 true;

--- a/testdata/TestBasicAutoFormat.docker.nix
+++ b/testdata/TestBasicAutoFormat.docker.nix
@@ -48,10 +48,10 @@
   };
   systemd.services."docker-jellyseerr" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "on-failure";
-      RestartMaxDelaySec = lib.mkOverride 500 "1m";
-      RestartSec = lib.mkOverride 500 "100ms";
-      RestartSteps = lib.mkOverride 500 9;
+      Restart = lib.mkOverride 90 "on-failure";
+      RestartMaxDelaySec = lib.mkOverride 90 "1m";
+      RestartSec = lib.mkOverride 90 "100ms";
+      RestartSteps = lib.mkOverride 90 9;
     };
     startLimitBurst = 3;
     unitConfig = {
@@ -98,11 +98,11 @@
   };
   systemd.services."docker-myproject-sabnzbd" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "always";
-      RestartMaxDelaySec = lib.mkOverride 500 "1m";
-      RestartSec = lib.mkOverride 500 "100ms";
-      RestartSteps = lib.mkOverride 500 9;
-      RuntimeMaxSec = lib.mkOverride 500 10;
+      Restart = lib.mkOverride 90 "always";
+      RestartMaxDelaySec = lib.mkOverride 90 "1m";
+      RestartSec = lib.mkOverride 90 "100ms";
+      RestartSteps = lib.mkOverride 90 9;
+      RuntimeMaxSec = lib.mkOverride 90 10;
     };
     unitConfig = {
       Description = lib.mkOverride 500 "This is the sabnzbd container!";
@@ -148,10 +148,10 @@
   };
   systemd.services."docker-photoprism-mariadb" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "always";
-      RestartMaxDelaySec = lib.mkOverride 500 "1m";
-      RestartSec = lib.mkOverride 500 "100ms";
-      RestartSteps = lib.mkOverride 500 9;
+      Restart = lib.mkOverride 90 "always";
+      RestartMaxDelaySec = lib.mkOverride 90 "1m";
+      RestartSec = lib.mkOverride 90 "100ms";
+      RestartSteps = lib.mkOverride 90 9;
     };
     startLimitBurst = 10;
     unitConfig = {
@@ -216,7 +216,7 @@
   };
   systemd.services."docker-torrent-client" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "on-failure";
+      Restart = lib.mkOverride 90 "on-failure";
     };
     startLimitBurst = 3;
     unitConfig = {
@@ -266,7 +266,7 @@
   };
   systemd.services."docker-traefik" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "no";
+      Restart = lib.mkOverride 90 "no";
     };
     unitConfig = {
       AllowIsolate = lib.mkOverride 500 true;

--- a/testdata/TestBasicAutoFormat.podman.nix
+++ b/testdata/TestBasicAutoFormat.podman.nix
@@ -53,8 +53,8 @@
   };
   systemd.services."podman-jellyseerr" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "on-failure";
-      RestartSec = lib.mkOverride 500 "5s";
+      Restart = lib.mkOverride 90 "on-failure";
+      RestartSec = lib.mkOverride 90 "5s";
     };
     startLimitBurst = 3;
     unitConfig = {
@@ -101,8 +101,8 @@
   };
   systemd.services."podman-myproject-sabnzbd" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "always";
-      RuntimeMaxSec = lib.mkOverride 500 10;
+      Restart = lib.mkOverride 90 "always";
+      RuntimeMaxSec = lib.mkOverride 90 10;
     };
     unitConfig = {
       Description = lib.mkOverride 500 "This is the sabnzbd container!";
@@ -149,8 +149,8 @@
   };
   systemd.services."podman-photoprism-mariadb" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "always";
-      RestartSec = lib.mkOverride 500 "3m0s";
+      Restart = lib.mkOverride 90 "always";
+      RestartSec = lib.mkOverride 90 "3m0s";
     };
     startLimitBurst = 10;
     unitConfig = {
@@ -214,7 +214,7 @@
   };
   systemd.services."podman-torrent-client" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "on-failure";
+      Restart = lib.mkOverride 90 "on-failure";
     };
     startLimitBurst = 3;
     unitConfig = {
@@ -264,7 +264,7 @@
   };
   systemd.services."podman-traefik" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "no";
+      Restart = lib.mkOverride 90 "no";
     };
     unitConfig = {
       AllowIsolate = lib.mkOverride 500 true;

--- a/testdata/TestComposeEnvFiles.docker.nix
+++ b/testdata/TestComposeEnvFiles.docker.nix
@@ -24,7 +24,7 @@
   };
   systemd.services."docker-test-first" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "no";
+      Restart = lib.mkOverride 90 "no";
     };
     after = [
       "docker-network-test_default.service"
@@ -48,7 +48,7 @@
   };
   systemd.services."docker-test-second" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "no";
+      Restart = lib.mkOverride 90 "no";
     };
     after = [
       "docker-network-test_default.service"

--- a/testdata/TestComposeEnvFiles.podman.nix
+++ b/testdata/TestComposeEnvFiles.podman.nix
@@ -29,7 +29,7 @@
   };
   systemd.services."podman-test-first" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "no";
+      Restart = lib.mkOverride 90 "no";
     };
     after = [
       "podman-network-test_default.service"
@@ -53,7 +53,7 @@
   };
   systemd.services."podman-test-second" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "no";
+      Restart = lib.mkOverride 90 "no";
     };
     after = [
       "podman-network-test_default.service"

--- a/testdata/TestDeployDevices.docker.nix
+++ b/testdata/TestDeployDevices.docker.nix
@@ -24,10 +24,10 @@
   };
   systemd.services."docker-test-test" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "always";
-      RestartMaxDelaySec = lib.mkOverride 500 "1m";
-      RestartSec = lib.mkOverride 500 "100ms";
-      RestartSteps = lib.mkOverride 500 9;
+      Restart = lib.mkOverride 90 "always";
+      RestartMaxDelaySec = lib.mkOverride 90 "1m";
+      RestartSec = lib.mkOverride 90 "100ms";
+      RestartSteps = lib.mkOverride 90 9;
     };
     after = [
       "docker-network-test_default.service"

--- a/testdata/TestDeployDevices.podman.nix
+++ b/testdata/TestDeployDevices.podman.nix
@@ -29,7 +29,7 @@
   };
   systemd.services."podman-test-test" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "always";
+      Restart = lib.mkOverride 90 "always";
     };
     after = [
       "podman-network-test_default.service"

--- a/testdata/TestEmptyEnv.docker.nix
+++ b/testdata/TestEmptyEnv.docker.nix
@@ -24,7 +24,7 @@
   };
   systemd.services."docker-test-service-a" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "no";
+      Restart = lib.mkOverride 90 "no";
     };
     after = [
       "docker-network-test_default.service"
@@ -48,7 +48,7 @@
   };
   systemd.services."docker-test-service-b" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "no";
+      Restart = lib.mkOverride 90 "no";
     };
     after = [
       "docker-network-test_default.service"

--- a/testdata/TestEmptyEnv.podman.nix
+++ b/testdata/TestEmptyEnv.podman.nix
@@ -29,7 +29,7 @@
   };
   systemd.services."podman-test-service-a" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "no";
+      Restart = lib.mkOverride 90 "no";
     };
     after = [
       "podman-network-test_default.service"
@@ -53,7 +53,7 @@
   };
   systemd.services."podman-test-service-b" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "no";
+      Restart = lib.mkOverride 90 "no";
     };
     after = [
       "podman-network-test_default.service"

--- a/testdata/TestEnvFilesOnly.docker.nix
+++ b/testdata/TestEnvFilesOnly.docker.nix
@@ -25,7 +25,7 @@
   };
   systemd.services."docker-test-first" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "no";
+      Restart = lib.mkOverride 90 "no";
     };
     after = [
       "docker-network-test_default.service"
@@ -49,7 +49,7 @@
   };
   systemd.services."docker-test-second" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "no";
+      Restart = lib.mkOverride 90 "no";
     };
     after = [
       "docker-network-test_default.service"

--- a/testdata/TestEnvFilesOnly.podman.nix
+++ b/testdata/TestEnvFilesOnly.podman.nix
@@ -30,7 +30,7 @@
   };
   systemd.services."podman-test-first" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "no";
+      Restart = lib.mkOverride 90 "no";
     };
     after = [
       "podman-network-test_default.service"
@@ -54,7 +54,7 @@
   };
   systemd.services."podman-test-second" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "no";
+      Restart = lib.mkOverride 90 "no";
     };
     after = [
       "podman-network-test_default.service"

--- a/testdata/TestExternalNetworksAndVolumes.docker.nix
+++ b/testdata/TestExternalNetworksAndVolumes.docker.nix
@@ -31,10 +31,10 @@
   };
   systemd.services."docker-traefik" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "always";
-      RestartMaxDelaySec = lib.mkOverride 500 "1m";
-      RestartSec = lib.mkOverride 500 "100ms";
-      RestartSteps = lib.mkOverride 500 9;
+      Restart = lib.mkOverride 90 "always";
+      RestartMaxDelaySec = lib.mkOverride 90 "1m";
+      RestartSec = lib.mkOverride 90 "100ms";
+      RestartSteps = lib.mkOverride 90 9;
     };
     after = [
       "docker-network-myproject_test1.service"

--- a/testdata/TestExternalNetworksAndVolumes.podman.nix
+++ b/testdata/TestExternalNetworksAndVolumes.podman.nix
@@ -35,7 +35,7 @@
   };
   systemd.services."podman-traefik" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "always";
+      Restart = lib.mkOverride 90 "always";
     };
     after = [
       "podman-network-myproject_test1.service"

--- a/testdata/TestMacvlanSupport.docker.nix
+++ b/testdata/TestMacvlanSupport.docker.nix
@@ -31,10 +31,10 @@
   };
   systemd.services."docker-container" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "always";
-      RestartMaxDelaySec = lib.mkOverride 500 "1m";
-      RestartSec = lib.mkOverride 500 "100ms";
-      RestartSteps = lib.mkOverride 500 9;
+      Restart = lib.mkOverride 90 "always";
+      RestartMaxDelaySec = lib.mkOverride 90 "1m";
+      RestartSec = lib.mkOverride 90 "100ms";
+      RestartSteps = lib.mkOverride 90 9;
     };
     after = [
       "docker-network-myproject_homenet.service"

--- a/testdata/TestMacvlanSupport.podman.nix
+++ b/testdata/TestMacvlanSupport.podman.nix
@@ -36,7 +36,7 @@
   };
   systemd.services."podman-container" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "always";
+      Restart = lib.mkOverride 90 "always";
     };
     after = [
       "podman-network-myproject_homenet.service"

--- a/testdata/TestMultipleNetworks.docker.nix
+++ b/testdata/TestMultipleNetworks.docker.nix
@@ -27,10 +27,10 @@
   };
   systemd.services."docker-traefik" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "always";
-      RestartMaxDelaySec = lib.mkOverride 500 "1m";
-      RestartSec = lib.mkOverride 500 "100ms";
-      RestartSteps = lib.mkOverride 500 9;
+      Restart = lib.mkOverride 90 "always";
+      RestartMaxDelaySec = lib.mkOverride 90 "1m";
+      RestartSec = lib.mkOverride 90 "100ms";
+      RestartSteps = lib.mkOverride 90 9;
     };
     after = [
       "docker-network-myproject_test1.service"

--- a/testdata/TestMultipleNetworks.podman.nix
+++ b/testdata/TestMultipleNetworks.podman.nix
@@ -31,7 +31,7 @@
   };
   systemd.services."podman-traefik" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "always";
+      Restart = lib.mkOverride 90 "always";
     };
     after = [
       "podman-network-myproject_test1.service"

--- a/testdata/TestNetworkAndVolumeNames.docker.nix
+++ b/testdata/TestNetworkAndVolumeNames.docker.nix
@@ -31,10 +31,10 @@
   };
   systemd.services."docker-traefik" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "always";
-      RestartMaxDelaySec = lib.mkOverride 500 "1m";
-      RestartSec = lib.mkOverride 500 "100ms";
-      RestartSteps = lib.mkOverride 500 9;
+      Restart = lib.mkOverride 90 "always";
+      RestartMaxDelaySec = lib.mkOverride 90 "1m";
+      RestartSec = lib.mkOverride 90 "100ms";
+      RestartSteps = lib.mkOverride 90 9;
     };
     after = [
       "docker-network-my-network.service"

--- a/testdata/TestNetworkAndVolumeNames.podman.nix
+++ b/testdata/TestNetworkAndVolumeNames.podman.nix
@@ -36,7 +36,7 @@
   };
   systemd.services."podman-traefik" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "always";
+      Restart = lib.mkOverride 90 "always";
     };
     after = [
       "podman-network-my-network.service"

--- a/testdata/TestNoCreateRootTarget.docker.nix
+++ b/testdata/TestNoCreateRootTarget.docker.nix
@@ -23,7 +23,7 @@
   };
   systemd.services."docker-test-service" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "no";
+      Restart = lib.mkOverride 90 "no";
     };
     after = [
       "docker-network-test_my-network.service"

--- a/testdata/TestNoCreateRootTarget.podman.nix
+++ b/testdata/TestNoCreateRootTarget.podman.nix
@@ -28,7 +28,7 @@
   };
   systemd.services."podman-test-service" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "no";
+      Restart = lib.mkOverride 90 "no";
     };
     after = [
       "podman-network-test_my-network.service"

--- a/testdata/TestNoRestart.docker.nix
+++ b/testdata/TestNoRestart.docker.nix
@@ -20,7 +20,7 @@
   };
   systemd.services."docker-test-test" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "no";
+      Restart = lib.mkOverride 90 "no";
     };
     after = [
       "docker-network-test_default.service"

--- a/testdata/TestNoRestart.podman.nix
+++ b/testdata/TestNoRestart.podman.nix
@@ -25,7 +25,7 @@
   };
   systemd.services."podman-test-test" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "no";
+      Restart = lib.mkOverride 90 "no";
     };
     after = [
       "podman-network-test_default.service"

--- a/testdata/TestNoWriteNixSetup.docker.nix
+++ b/testdata/TestNoWriteNixSetup.docker.nix
@@ -41,10 +41,10 @@
   };
   systemd.services."docker-jellyseerr" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "on-failure";
-      RestartMaxDelaySec = lib.mkOverride 500 "1m";
-      RestartSec = lib.mkOverride 500 "100ms";
-      RestartSteps = lib.mkOverride 500 9;
+      Restart = lib.mkOverride 90 "on-failure";
+      RestartMaxDelaySec = lib.mkOverride 90 "1m";
+      RestartSec = lib.mkOverride 90 "100ms";
+      RestartSteps = lib.mkOverride 90 9;
     };
     startLimitBurst = 3;
     unitConfig = {
@@ -94,11 +94,11 @@
   };
   systemd.services."docker-myproject-sabnzbd" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "always";
-      RestartMaxDelaySec = lib.mkOverride 500 "1m";
-      RestartSec = lib.mkOverride 500 "100ms";
-      RestartSteps = lib.mkOverride 500 9;
-      RuntimeMaxSec = lib.mkOverride 500 10;
+      Restart = lib.mkOverride 90 "always";
+      RestartMaxDelaySec = lib.mkOverride 90 "1m";
+      RestartSec = lib.mkOverride 90 "100ms";
+      RestartSteps = lib.mkOverride 90 9;
+      RuntimeMaxSec = lib.mkOverride 90 10;
     };
     unitConfig = {
       Description = lib.mkOverride 500 "This is the sabnzbd container!";
@@ -143,10 +143,10 @@
   };
   systemd.services."docker-photoprism-mariadb" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "always";
-      RestartMaxDelaySec = lib.mkOverride 500 "1m";
-      RestartSec = lib.mkOverride 500 "100ms";
-      RestartSteps = lib.mkOverride 500 9;
+      Restart = lib.mkOverride 90 "always";
+      RestartMaxDelaySec = lib.mkOverride 90 "1m";
+      RestartSec = lib.mkOverride 90 "100ms";
+      RestartSteps = lib.mkOverride 90 9;
     };
     startLimitBurst = 10;
     unitConfig = {
@@ -217,7 +217,7 @@
   };
   systemd.services."docker-torrent-client" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "on-failure";
+      Restart = lib.mkOverride 90 "on-failure";
     };
     startLimitBurst = 3;
     unitConfig = {
@@ -270,7 +270,7 @@
   };
   systemd.services."docker-traefik" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "no";
+      Restart = lib.mkOverride 90 "no";
     };
     unitConfig = {
       AllowIsolate = lib.mkOverride 500 true;

--- a/testdata/TestNoWriteNixSetup.podman.nix
+++ b/testdata/TestNoWriteNixSetup.podman.nix
@@ -41,8 +41,8 @@
   };
   systemd.services."podman-jellyseerr" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "on-failure";
-      RestartSec = lib.mkOverride 500 "5s";
+      Restart = lib.mkOverride 90 "on-failure";
+      RestartSec = lib.mkOverride 90 "5s";
     };
     startLimitBurst = 3;
     unitConfig = {
@@ -92,8 +92,8 @@
   };
   systemd.services."podman-myproject-sabnzbd" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "always";
-      RuntimeMaxSec = lib.mkOverride 500 10;
+      Restart = lib.mkOverride 90 "always";
+      RuntimeMaxSec = lib.mkOverride 90 10;
     };
     unitConfig = {
       Description = lib.mkOverride 500 "This is the sabnzbd container!";
@@ -139,8 +139,8 @@
   };
   systemd.services."podman-photoprism-mariadb" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "always";
-      RestartSec = lib.mkOverride 500 "3m0s";
+      Restart = lib.mkOverride 90 "always";
+      RestartSec = lib.mkOverride 90 "3m0s";
     };
     startLimitBurst = 10;
     unitConfig = {
@@ -210,7 +210,7 @@
   };
   systemd.services."podman-torrent-client" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "on-failure";
+      Restart = lib.mkOverride 90 "on-failure";
     };
     startLimitBurst = 3;
     unitConfig = {
@@ -263,7 +263,7 @@
   };
   systemd.services."podman-traefik" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "no";
+      Restart = lib.mkOverride 90 "no";
     };
     unitConfig = {
       AllowIsolate = lib.mkOverride 500 true;

--- a/testdata/TestOverrideSystemdStopTimeout.docker.nix
+++ b/testdata/TestOverrideSystemdStopTimeout.docker.nix
@@ -47,11 +47,11 @@
   };
   systemd.services."docker-jellyseerr" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "on-failure";
-      RestartMaxDelaySec = lib.mkOverride 500 "1m";
-      RestartSec = lib.mkOverride 500 "100ms";
-      RestartSteps = lib.mkOverride 500 9;
-      TimeoutStopSec = lib.mkOverride 500 10;
+      Restart = lib.mkOverride 90 "on-failure";
+      RestartMaxDelaySec = lib.mkOverride 90 "1m";
+      RestartSec = lib.mkOverride 90 "100ms";
+      RestartSteps = lib.mkOverride 90 9;
+      TimeoutStopSec = lib.mkOverride 90 10;
     };
     startLimitBurst = 3;
     unitConfig = {
@@ -101,12 +101,12 @@
   };
   systemd.services."docker-myproject-sabnzbd" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "always";
-      RestartMaxDelaySec = lib.mkOverride 500 "1m";
-      RestartSec = lib.mkOverride 500 "100ms";
-      RestartSteps = lib.mkOverride 500 9;
-      RuntimeMaxSec = lib.mkOverride 500 10;
-      TimeoutStopSec = lib.mkOverride 500 10;
+      Restart = lib.mkOverride 90 "always";
+      RestartMaxDelaySec = lib.mkOverride 90 "1m";
+      RestartSec = lib.mkOverride 90 "100ms";
+      RestartSteps = lib.mkOverride 90 9;
+      RuntimeMaxSec = lib.mkOverride 90 10;
+      TimeoutStopSec = lib.mkOverride 90 10;
     };
     unitConfig = {
       Description = lib.mkOverride 500 "This is the sabnzbd container!";
@@ -151,11 +151,11 @@
   };
   systemd.services."docker-photoprism-mariadb" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "always";
-      RestartMaxDelaySec = lib.mkOverride 500 "1m";
-      RestartSec = lib.mkOverride 500 "100ms";
-      RestartSteps = lib.mkOverride 500 9;
-      TimeoutStopSec = lib.mkOverride 500 10;
+      Restart = lib.mkOverride 90 "always";
+      RestartMaxDelaySec = lib.mkOverride 90 "1m";
+      RestartSec = lib.mkOverride 90 "100ms";
+      RestartSteps = lib.mkOverride 90 9;
+      TimeoutStopSec = lib.mkOverride 90 10;
     };
     startLimitBurst = 10;
     unitConfig = {
@@ -226,8 +226,8 @@
   };
   systemd.services."docker-torrent-client" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "on-failure";
-      TimeoutStopSec = lib.mkOverride 500 10;
+      Restart = lib.mkOverride 90 "on-failure";
+      TimeoutStopSec = lib.mkOverride 90 10;
     };
     startLimitBurst = 3;
     unitConfig = {
@@ -280,8 +280,8 @@
   };
   systemd.services."docker-traefik" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "no";
-      TimeoutStopSec = lib.mkOverride 500 10;
+      Restart = lib.mkOverride 90 "no";
+      TimeoutStopSec = lib.mkOverride 90 10;
     };
     unitConfig = {
       AllowIsolate = lib.mkOverride 500 true;

--- a/testdata/TestOverrideSystemdStopTimeout.podman.nix
+++ b/testdata/TestOverrideSystemdStopTimeout.podman.nix
@@ -52,9 +52,9 @@
   };
   systemd.services."podman-jellyseerr" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "on-failure";
-      RestartSec = lib.mkOverride 500 "5s";
-      TimeoutStopSec = lib.mkOverride 500 10;
+      Restart = lib.mkOverride 90 "on-failure";
+      RestartSec = lib.mkOverride 90 "5s";
+      TimeoutStopSec = lib.mkOverride 90 10;
     };
     startLimitBurst = 3;
     unitConfig = {
@@ -104,9 +104,9 @@
   };
   systemd.services."podman-myproject-sabnzbd" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "always";
-      RuntimeMaxSec = lib.mkOverride 500 10;
-      TimeoutStopSec = lib.mkOverride 500 10;
+      Restart = lib.mkOverride 90 "always";
+      RuntimeMaxSec = lib.mkOverride 90 10;
+      TimeoutStopSec = lib.mkOverride 90 10;
     };
     unitConfig = {
       Description = lib.mkOverride 500 "This is the sabnzbd container!";
@@ -152,9 +152,9 @@
   };
   systemd.services."podman-photoprism-mariadb" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "always";
-      RestartSec = lib.mkOverride 500 "3m0s";
-      TimeoutStopSec = lib.mkOverride 500 10;
+      Restart = lib.mkOverride 90 "always";
+      RestartSec = lib.mkOverride 90 "3m0s";
+      TimeoutStopSec = lib.mkOverride 90 10;
     };
     startLimitBurst = 10;
     unitConfig = {
@@ -224,8 +224,8 @@
   };
   systemd.services."podman-torrent-client" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "on-failure";
-      TimeoutStopSec = lib.mkOverride 500 10;
+      Restart = lib.mkOverride 90 "on-failure";
+      TimeoutStopSec = lib.mkOverride 90 10;
     };
     startLimitBurst = 3;
     unitConfig = {
@@ -278,8 +278,8 @@
   };
   systemd.services."podman-traefik" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "no";
-      TimeoutStopSec = lib.mkOverride 500 10;
+      Restart = lib.mkOverride 90 "no";
+      TimeoutStopSec = lib.mkOverride 90 10;
     };
     unitConfig = {
       AllowIsolate = lib.mkOverride 500 true;

--- a/testdata/TestProject.docker.nix
+++ b/testdata/TestProject.docker.nix
@@ -47,10 +47,10 @@
   };
   systemd.services."docker-jellyseerr" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "on-failure";
-      RestartMaxDelaySec = lib.mkOverride 500 "1m";
-      RestartSec = lib.mkOverride 500 "100ms";
-      RestartSteps = lib.mkOverride 500 9;
+      Restart = lib.mkOverride 90 "on-failure";
+      RestartMaxDelaySec = lib.mkOverride 90 "1m";
+      RestartSec = lib.mkOverride 90 "100ms";
+      RestartSteps = lib.mkOverride 90 9;
     };
     startLimitBurst = 3;
     unitConfig = {
@@ -100,11 +100,11 @@
   };
   systemd.services."docker-myproject-sabnzbd" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "always";
-      RestartMaxDelaySec = lib.mkOverride 500 "1m";
-      RestartSec = lib.mkOverride 500 "100ms";
-      RestartSteps = lib.mkOverride 500 9;
-      RuntimeMaxSec = lib.mkOverride 500 10;
+      Restart = lib.mkOverride 90 "always";
+      RestartMaxDelaySec = lib.mkOverride 90 "1m";
+      RestartSec = lib.mkOverride 90 "100ms";
+      RestartSteps = lib.mkOverride 90 9;
+      RuntimeMaxSec = lib.mkOverride 90 10;
     };
     unitConfig = {
       Description = lib.mkOverride 500 "This is the sabnzbd container!";
@@ -149,10 +149,10 @@
   };
   systemd.services."docker-photoprism-mariadb" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "always";
-      RestartMaxDelaySec = lib.mkOverride 500 "1m";
-      RestartSec = lib.mkOverride 500 "100ms";
-      RestartSteps = lib.mkOverride 500 9;
+      Restart = lib.mkOverride 90 "always";
+      RestartMaxDelaySec = lib.mkOverride 90 "1m";
+      RestartSec = lib.mkOverride 90 "100ms";
+      RestartSteps = lib.mkOverride 90 9;
     };
     startLimitBurst = 10;
     unitConfig = {
@@ -223,7 +223,7 @@
   };
   systemd.services."docker-torrent-client" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "on-failure";
+      Restart = lib.mkOverride 90 "on-failure";
     };
     startLimitBurst = 3;
     unitConfig = {
@@ -276,7 +276,7 @@
   };
   systemd.services."docker-traefik" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "no";
+      Restart = lib.mkOverride 90 "no";
     };
     unitConfig = {
       AllowIsolate = lib.mkOverride 500 true;

--- a/testdata/TestProject.podman.nix
+++ b/testdata/TestProject.podman.nix
@@ -52,8 +52,8 @@
   };
   systemd.services."podman-jellyseerr" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "on-failure";
-      RestartSec = lib.mkOverride 500 "5s";
+      Restart = lib.mkOverride 90 "on-failure";
+      RestartSec = lib.mkOverride 90 "5s";
     };
     startLimitBurst = 3;
     unitConfig = {
@@ -103,8 +103,8 @@
   };
   systemd.services."podman-myproject-sabnzbd" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "always";
-      RuntimeMaxSec = lib.mkOverride 500 10;
+      Restart = lib.mkOverride 90 "always";
+      RuntimeMaxSec = lib.mkOverride 90 10;
     };
     unitConfig = {
       Description = lib.mkOverride 500 "This is the sabnzbd container!";
@@ -150,8 +150,8 @@
   };
   systemd.services."podman-photoprism-mariadb" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "always";
-      RestartSec = lib.mkOverride 500 "3m0s";
+      Restart = lib.mkOverride 90 "always";
+      RestartSec = lib.mkOverride 90 "3m0s";
     };
     startLimitBurst = 10;
     unitConfig = {
@@ -221,7 +221,7 @@
   };
   systemd.services."podman-torrent-client" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "on-failure";
+      Restart = lib.mkOverride 90 "on-failure";
     };
     startLimitBurst = 3;
     unitConfig = {
@@ -274,7 +274,7 @@
   };
   systemd.services."podman-traefik" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "no";
+      Restart = lib.mkOverride 90 "no";
     };
     unitConfig = {
       AllowIsolate = lib.mkOverride 500 true;

--- a/testdata/TestRelativeServiceVolumes.docker.nix
+++ b/testdata/TestRelativeServiceVolumes.docker.nix
@@ -29,10 +29,10 @@
   };
   systemd.services."docker-traefik" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "always";
-      RestartMaxDelaySec = lib.mkOverride 500 "1m";
-      RestartSec = lib.mkOverride 500 "100ms";
-      RestartSteps = lib.mkOverride 500 9;
+      Restart = lib.mkOverride 90 "always";
+      RestartMaxDelaySec = lib.mkOverride 90 "1m";
+      RestartSec = lib.mkOverride 90 "100ms";
+      RestartSteps = lib.mkOverride 90 9;
     };
     after = [
       "docker-network-myproject_default.service"

--- a/testdata/TestRelativeServiceVolumes.podman.nix
+++ b/testdata/TestRelativeServiceVolumes.podman.nix
@@ -34,7 +34,7 @@
   };
   systemd.services."podman-traefik" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "always";
+      Restart = lib.mkOverride 90 "always";
     };
     after = [
       "podman-network-myproject_default.service"

--- a/testdata/TestRelativeServiceVolumes_CurrentDirectory.docker.nix
+++ b/testdata/TestRelativeServiceVolumes_CurrentDirectory.docker.nix
@@ -28,10 +28,10 @@
   };
   systemd.services."docker-traefik" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "always";
-      RestartMaxDelaySec = lib.mkOverride 500 "1m";
-      RestartSec = lib.mkOverride 500 "100ms";
-      RestartSteps = lib.mkOverride 500 9;
+      Restart = lib.mkOverride 90 "always";
+      RestartMaxDelaySec = lib.mkOverride 90 "1m";
+      RestartSec = lib.mkOverride 90 "100ms";
+      RestartSteps = lib.mkOverride 90 9;
     };
     after = [
       "docker-network-myproject_default.service"

--- a/testdata/TestRelativeServiceVolumes_CurrentDirectory.podman.nix
+++ b/testdata/TestRelativeServiceVolumes_CurrentDirectory.podman.nix
@@ -33,7 +33,7 @@
   };
   systemd.services."podman-traefik" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "always";
+      Restart = lib.mkOverride 90 "always";
     };
     after = [
       "podman-network-myproject_default.service"

--- a/testdata/TestRemoveVolumes.docker.nix
+++ b/testdata/TestRemoveVolumes.docker.nix
@@ -47,10 +47,10 @@
   };
   systemd.services."docker-jellyseerr" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "on-failure";
-      RestartMaxDelaySec = lib.mkOverride 500 "1m";
-      RestartSec = lib.mkOverride 500 "100ms";
-      RestartSteps = lib.mkOverride 500 9;
+      Restart = lib.mkOverride 90 "on-failure";
+      RestartMaxDelaySec = lib.mkOverride 90 "1m";
+      RestartSec = lib.mkOverride 90 "100ms";
+      RestartSteps = lib.mkOverride 90 9;
     };
     startLimitBurst = 3;
     unitConfig = {
@@ -100,11 +100,11 @@
   };
   systemd.services."docker-myproject-sabnzbd" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "always";
-      RestartMaxDelaySec = lib.mkOverride 500 "1m";
-      RestartSec = lib.mkOverride 500 "100ms";
-      RestartSteps = lib.mkOverride 500 9;
-      RuntimeMaxSec = lib.mkOverride 500 10;
+      Restart = lib.mkOverride 90 "always";
+      RestartMaxDelaySec = lib.mkOverride 90 "1m";
+      RestartSec = lib.mkOverride 90 "100ms";
+      RestartSteps = lib.mkOverride 90 9;
+      RuntimeMaxSec = lib.mkOverride 90 10;
     };
     unitConfig = {
       Description = lib.mkOverride 500 "This is the sabnzbd container!";
@@ -149,10 +149,10 @@
   };
   systemd.services."docker-photoprism-mariadb" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "always";
-      RestartMaxDelaySec = lib.mkOverride 500 "1m";
-      RestartSec = lib.mkOverride 500 "100ms";
-      RestartSteps = lib.mkOverride 500 9;
+      Restart = lib.mkOverride 90 "always";
+      RestartMaxDelaySec = lib.mkOverride 90 "1m";
+      RestartSec = lib.mkOverride 90 "100ms";
+      RestartSteps = lib.mkOverride 90 9;
     };
     startLimitBurst = 10;
     unitConfig = {
@@ -223,7 +223,7 @@
   };
   systemd.services."docker-torrent-client" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "on-failure";
+      Restart = lib.mkOverride 90 "on-failure";
     };
     startLimitBurst = 3;
     unitConfig = {
@@ -276,7 +276,7 @@
   };
   systemd.services."docker-traefik" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "no";
+      Restart = lib.mkOverride 90 "no";
     };
     unitConfig = {
       AllowIsolate = lib.mkOverride 500 true;

--- a/testdata/TestRemoveVolumes.podman.nix
+++ b/testdata/TestRemoveVolumes.podman.nix
@@ -52,8 +52,8 @@
   };
   systemd.services."podman-jellyseerr" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "on-failure";
-      RestartSec = lib.mkOverride 500 "5s";
+      Restart = lib.mkOverride 90 "on-failure";
+      RestartSec = lib.mkOverride 90 "5s";
     };
     startLimitBurst = 3;
     unitConfig = {
@@ -103,8 +103,8 @@
   };
   systemd.services."podman-myproject-sabnzbd" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "always";
-      RuntimeMaxSec = lib.mkOverride 500 10;
+      Restart = lib.mkOverride 90 "always";
+      RuntimeMaxSec = lib.mkOverride 90 10;
     };
     unitConfig = {
       Description = lib.mkOverride 500 "This is the sabnzbd container!";
@@ -150,8 +150,8 @@
   };
   systemd.services."podman-photoprism-mariadb" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "always";
-      RestartSec = lib.mkOverride 500 "3m0s";
+      Restart = lib.mkOverride 90 "always";
+      RestartSec = lib.mkOverride 90 "3m0s";
     };
     startLimitBurst = 10;
     unitConfig = {
@@ -221,7 +221,7 @@
   };
   systemd.services."podman-torrent-client" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "on-failure";
+      Restart = lib.mkOverride 90 "on-failure";
     };
     startLimitBurst = 3;
     unitConfig = {
@@ -274,7 +274,7 @@
   };
   systemd.services."podman-traefik" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "no";
+      Restart = lib.mkOverride 90 "no";
     };
     unitConfig = {
       AllowIsolate = lib.mkOverride 500 true;

--- a/testdata/TestSystemdMount.docker.nix
+++ b/testdata/TestSystemdMount.docker.nix
@@ -47,10 +47,10 @@
   };
   systemd.services."docker-jellyseerr" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "on-failure";
-      RestartMaxDelaySec = lib.mkOverride 500 "1m";
-      RestartSec = lib.mkOverride 500 "100ms";
-      RestartSteps = lib.mkOverride 500 9;
+      Restart = lib.mkOverride 90 "on-failure";
+      RestartMaxDelaySec = lib.mkOverride 90 "1m";
+      RestartSec = lib.mkOverride 90 "100ms";
+      RestartSteps = lib.mkOverride 90 9;
     };
     startLimitBurst = 3;
     unitConfig = {
@@ -103,11 +103,11 @@
   };
   systemd.services."docker-myproject-sabnzbd" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "always";
-      RestartMaxDelaySec = lib.mkOverride 500 "1m";
-      RestartSec = lib.mkOverride 500 "100ms";
-      RestartSteps = lib.mkOverride 500 9;
-      RuntimeMaxSec = lib.mkOverride 500 10;
+      Restart = lib.mkOverride 90 "always";
+      RestartMaxDelaySec = lib.mkOverride 90 "1m";
+      RestartSec = lib.mkOverride 90 "100ms";
+      RestartSteps = lib.mkOverride 90 9;
+      RuntimeMaxSec = lib.mkOverride 90 10;
     };
     unitConfig = {
       Description = lib.mkOverride 500 "This is the sabnzbd container!";
@@ -155,10 +155,10 @@
   };
   systemd.services."docker-photoprism-mariadb" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "always";
-      RestartMaxDelaySec = lib.mkOverride 500 "1m";
-      RestartSec = lib.mkOverride 500 "100ms";
-      RestartSteps = lib.mkOverride 500 9;
+      Restart = lib.mkOverride 90 "always";
+      RestartMaxDelaySec = lib.mkOverride 90 "1m";
+      RestartSec = lib.mkOverride 90 "100ms";
+      RestartSteps = lib.mkOverride 90 9;
     };
     startLimitBurst = 10;
     unitConfig = {
@@ -232,7 +232,7 @@
   };
   systemd.services."docker-torrent-client" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "on-failure";
+      Restart = lib.mkOverride 90 "on-failure";
     };
     startLimitBurst = 3;
     unitConfig = {
@@ -290,7 +290,7 @@
   };
   systemd.services."docker-traefik" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "no";
+      Restart = lib.mkOverride 90 "no";
     };
     unitConfig = {
       AllowIsolate = lib.mkOverride 500 true;

--- a/testdata/TestSystemdMount.podman.nix
+++ b/testdata/TestSystemdMount.podman.nix
@@ -52,8 +52,8 @@
   };
   systemd.services."podman-jellyseerr" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "on-failure";
-      RestartSec = lib.mkOverride 500 "5s";
+      Restart = lib.mkOverride 90 "on-failure";
+      RestartSec = lib.mkOverride 90 "5s";
     };
     startLimitBurst = 3;
     unitConfig = {
@@ -106,8 +106,8 @@
   };
   systemd.services."podman-myproject-sabnzbd" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "always";
-      RuntimeMaxSec = lib.mkOverride 500 10;
+      Restart = lib.mkOverride 90 "always";
+      RuntimeMaxSec = lib.mkOverride 90 10;
     };
     unitConfig = {
       Description = lib.mkOverride 500 "This is the sabnzbd container!";
@@ -156,8 +156,8 @@
   };
   systemd.services."podman-photoprism-mariadb" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "always";
-      RestartSec = lib.mkOverride 500 "3m0s";
+      Restart = lib.mkOverride 90 "always";
+      RestartSec = lib.mkOverride 90 "3m0s";
     };
     startLimitBurst = 10;
     unitConfig = {
@@ -230,7 +230,7 @@
   };
   systemd.services."podman-torrent-client" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "on-failure";
+      Restart = lib.mkOverride 90 "on-failure";
     };
     startLimitBurst = 3;
     unitConfig = {
@@ -288,7 +288,7 @@
   };
   systemd.services."podman-traefik" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "no";
+      Restart = lib.mkOverride 90 "no";
     };
     unitConfig = {
       AllowIsolate = lib.mkOverride 500 true;

--- a/testdata/TestUpheldBy.docker.nix
+++ b/testdata/TestUpheldBy.docker.nix
@@ -47,10 +47,10 @@
   };
   systemd.services."docker-jellyseerr" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "on-failure";
-      RestartMaxDelaySec = lib.mkOverride 500 "1m";
-      RestartSec = lib.mkOverride 500 "100ms";
-      RestartSteps = lib.mkOverride 500 9;
+      Restart = lib.mkOverride 90 "on-failure";
+      RestartMaxDelaySec = lib.mkOverride 90 "1m";
+      RestartSec = lib.mkOverride 90 "100ms";
+      RestartSteps = lib.mkOverride 90 9;
     };
     startLimitBurst = 3;
     unitConfig = {
@@ -103,11 +103,11 @@
   };
   systemd.services."docker-myproject-sabnzbd" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "always";
-      RestartMaxDelaySec = lib.mkOverride 500 "1m";
-      RestartSec = lib.mkOverride 500 "100ms";
-      RestartSteps = lib.mkOverride 500 9;
-      RuntimeMaxSec = lib.mkOverride 500 10;
+      Restart = lib.mkOverride 90 "always";
+      RestartMaxDelaySec = lib.mkOverride 90 "1m";
+      RestartSec = lib.mkOverride 90 "100ms";
+      RestartSteps = lib.mkOverride 90 9;
+      RuntimeMaxSec = lib.mkOverride 90 10;
     };
     unitConfig = {
       Description = lib.mkOverride 500 "This is the sabnzbd container!";
@@ -152,10 +152,10 @@
   };
   systemd.services."docker-photoprism-mariadb" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "always";
-      RestartMaxDelaySec = lib.mkOverride 500 "1m";
-      RestartSec = lib.mkOverride 500 "100ms";
-      RestartSteps = lib.mkOverride 500 9;
+      Restart = lib.mkOverride 90 "always";
+      RestartMaxDelaySec = lib.mkOverride 90 "1m";
+      RestartSec = lib.mkOverride 90 "100ms";
+      RestartSteps = lib.mkOverride 90 9;
     };
     startLimitBurst = 10;
     unitConfig = {
@@ -226,7 +226,7 @@
   };
   systemd.services."docker-torrent-client" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "on-failure";
+      Restart = lib.mkOverride 90 "on-failure";
     };
     startLimitBurst = 3;
     unitConfig = {
@@ -282,7 +282,7 @@
   };
   systemd.services."docker-traefik" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "no";
+      Restart = lib.mkOverride 90 "no";
     };
     unitConfig = {
       AllowIsolate = lib.mkOverride 500 true;

--- a/testdata/TestUpheldBy.podman.nix
+++ b/testdata/TestUpheldBy.podman.nix
@@ -52,8 +52,8 @@
   };
   systemd.services."podman-jellyseerr" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "on-failure";
-      RestartSec = lib.mkOverride 500 "5s";
+      Restart = lib.mkOverride 90 "on-failure";
+      RestartSec = lib.mkOverride 90 "5s";
     };
     startLimitBurst = 3;
     unitConfig = {
@@ -106,8 +106,8 @@
   };
   systemd.services."podman-myproject-sabnzbd" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "always";
-      RuntimeMaxSec = lib.mkOverride 500 10;
+      Restart = lib.mkOverride 90 "always";
+      RuntimeMaxSec = lib.mkOverride 90 10;
     };
     unitConfig = {
       Description = lib.mkOverride 500 "This is the sabnzbd container!";
@@ -153,8 +153,8 @@
   };
   systemd.services."podman-photoprism-mariadb" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "always";
-      RestartSec = lib.mkOverride 500 "3m0s";
+      Restart = lib.mkOverride 90 "always";
+      RestartSec = lib.mkOverride 90 "3m0s";
     };
     startLimitBurst = 10;
     unitConfig = {
@@ -224,7 +224,7 @@
   };
   systemd.services."podman-torrent-client" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "on-failure";
+      Restart = lib.mkOverride 90 "on-failure";
     };
     startLimitBurst = 3;
     unitConfig = {
@@ -280,7 +280,7 @@
   };
   systemd.services."podman-traefik" = {
     serviceConfig = {
-      Restart = lib.mkOverride 500 "no";
+      Restart = lib.mkOverride 90 "no";
     };
     unitConfig = {
       AllowIsolate = lib.mkOverride 500 true;


### PR DESCRIPTION
Previously, I had used a priority of 500 thinking that the "default" is 1000. Turns out that Nix sets a priority of 100 to regular assigments. Since the `oci-containers` module sets `Restart=always`, it ends up silently overriding any value set by compose2nix.

To fix this, I am bumping down the priority to 90. I've also added an integration test to verify that we indeed override the NixOS module.

Fixes #46.