### PR TITLE
Podman DNS match pattern for nftables

### DIFF
--- a/nixos-test/podman-compose.nix
+++ b/nixos-test/podman-compose.nix
@@ -1,5 +1,5 @@
 # Auto-generated using compose2nix v0.3.2-pre.
-{ pkgs, lib, ... }:
+{ pkgs, lib, config, ... }:
 
 {
   # Runtime
@@ -7,15 +7,15 @@
     enable = true;
     autoPrune.enable = true;
     dockerCompat = true;
-    defaultNetwork.settings = {
-      # Required for container networking to be able to use names.
-      dns_enabled = true;
-    };
   };
 
-  # Enable container name DNS for non-default Podman networks.
-  # https://github.com/NixOS/nixpkgs/issues/226365
-  networking.firewall.interfaces."podman+".allowedUDPPorts = [ 53 ];
+  # Enable container name DNS for all Podman networks.
+  # See: https://github.com/NixOS/nixpkgs/issues/226365
+  networking.firewall.interfaces = let
+    matchAll = if !config.networking.nftables.enable then "podman+" else "podman*";
+  in {
+    "${matchAll}".allowedUDPPorts = [ 53 ];
+  };
 
   virtualisation.oci-containers.backend = "podman";
 

--- a/nixos-test/test.nix
+++ b/nixos-test/test.nix
@@ -77,6 +77,10 @@ in
       m.succeed(f"systemctl show -p Restart {runtime}-service-b.service | grep -E '=on-success$'")
       m.succeed(f"systemctl show -p Restart {runtime}-myproject-no-restart.service | grep -E '=no$'")
 
+      # Ensure we can reach a container in the same network. Regression test
+      # for DNS settings, especially for Podman.
+      m.succeed(f"{runtime} exec -it myproject-service-a wget http://no-restart")
+
       # Stop the root unit.
       m.systemctl(f"stop {runtime}-compose-myproject-root.target")
   '';

--- a/templates/main.nix.tmpl
+++ b/templates/main.nix.tmpl
@@ -1,6 +1,8 @@
 {{- if .Version -}}
 # Auto-generated using compose2nix v{{.Version}}.
-{ pkgs, lib, ... }:
+{{end -}}
+{{- if eq (.Runtime | printf "%s") "podman" -}}
+{ pkgs, lib, config, ... }:
 {{- else -}}
 { pkgs, lib, ... }:
 {{- end}}
@@ -13,17 +15,16 @@
     autoPrune.enable = true;
     {{- if eq (.Runtime | printf "%s") "podman"}}
     dockerCompat = true;
-    defaultNetwork.settings = {
-      # Required for container networking to be able to use names.
-      dns_enabled = true;
-    };
     {{- end}}
   };
   {{- if eq (.Runtime | printf "%s") "podman"}}
 
-  # Enable container name DNS for non-default Podman networks.
-  # https://github.com/NixOS/nixpkgs/issues/226365
-  networking.firewall.interfaces."podman+".allowedUDPPorts = [ 53 ];
+  # Enable container name DNS for all Podman networks.
+  networking.firewall.interfaces = let
+    matchAll = if !config.networking.nftables.enable then "podman+" else "podman*";
+  in {
+    "${matchAll}".allowedUDPPorts = [ 53 ];
+  };
 
   virtualisation.oci-containers.backend = "{{.Runtime}}";
   {{- else}}

--- a/testdata/TestAutoStart.podman.nix
+++ b/testdata/TestAutoStart.podman.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib, ... }:
+{ pkgs, lib, config, ... }:
 
 {
   # Runtime
@@ -6,15 +6,14 @@
     enable = true;
     autoPrune.enable = true;
     dockerCompat = true;
-    defaultNetwork.settings = {
-      # Required for container networking to be able to use names.
-      dns_enabled = true;
-    };
   };
 
-  # Enable container name DNS for non-default Podman networks.
-  # https://github.com/NixOS/nixpkgs/issues/226365
-  networking.firewall.interfaces."podman+".allowedUDPPorts = [ 53 ];
+  # Enable container name DNS for all Podman networks.
+  networking.firewall.interfaces = let
+    matchAll = if !config.networking.nftables.enable then "podman+" else "podman*";
+  in {
+    "${matchAll}".allowedUDPPorts = [ 53 ];
+  };
 
   virtualisation.oci-containers.backend = "podman";
 

--- a/testdata/TestBasic.podman.nix
+++ b/testdata/TestBasic.podman.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib, ... }:
+{ pkgs, lib, config, ... }:
 
 {
   # Runtime
@@ -6,15 +6,14 @@
     enable = true;
     autoPrune.enable = true;
     dockerCompat = true;
-    defaultNetwork.settings = {
-      # Required for container networking to be able to use names.
-      dns_enabled = true;
-    };
   };
 
-  # Enable container name DNS for non-default Podman networks.
-  # https://github.com/NixOS/nixpkgs/issues/226365
-  networking.firewall.interfaces."podman+".allowedUDPPorts = [ 53 ];
+  # Enable container name DNS for all Podman networks.
+  networking.firewall.interfaces = let
+    matchAll = if !config.networking.nftables.enable then "podman+" else "podman*";
+  in {
+    "${matchAll}".allowedUDPPorts = [ 53 ];
+  };
 
   virtualisation.oci-containers.backend = "podman";
 

--- a/testdata/TestBasicAutoFormat.podman.nix
+++ b/testdata/TestBasicAutoFormat.podman.nix
@@ -1,4 +1,9 @@
-{ pkgs, lib, ... }:
+{
+  pkgs,
+  lib,
+  config,
+  ...
+}:
 
 {
   # Runtime
@@ -6,15 +11,16 @@
     enable = true;
     autoPrune.enable = true;
     dockerCompat = true;
-    defaultNetwork.settings = {
-      # Required for container networking to be able to use names.
-      dns_enabled = true;
-    };
   };
 
-  # Enable container name DNS for non-default Podman networks.
-  # https://github.com/NixOS/nixpkgs/issues/226365
-  networking.firewall.interfaces."podman+".allowedUDPPorts = [ 53 ];
+  # Enable container name DNS for all Podman networks.
+  networking.firewall.interfaces =
+    let
+      matchAll = if !config.networking.nftables.enable then "podman+" else "podman*";
+    in
+    {
+      "${matchAll}".allowedUDPPorts = [ 53 ];
+    };
 
   virtualisation.oci-containers.backend = "podman";
 

--- a/testdata/TestBuildSpec.podman.nix
+++ b/testdata/TestBuildSpec.podman.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib, ... }:
+{ pkgs, lib, config, ... }:
 
 {
   # Runtime
@@ -6,15 +6,14 @@
     enable = true;
     autoPrune.enable = true;
     dockerCompat = true;
-    defaultNetwork.settings = {
-      # Required for container networking to be able to use names.
-      dns_enabled = true;
-    };
   };
 
-  # Enable container name DNS for non-default Podman networks.
-  # https://github.com/NixOS/nixpkgs/issues/226365
-  networking.firewall.interfaces."podman+".allowedUDPPorts = [ 53 ];
+  # Enable container name DNS for all Podman networks.
+  networking.firewall.interfaces = let
+    matchAll = if !config.networking.nftables.enable then "podman+" else "podman*";
+  in {
+    "${matchAll}".allowedUDPPorts = [ 53 ];
+  };
 
   virtualisation.oci-containers.backend = "podman";
 

--- a/testdata/TestBuildSpec_BuildEnabled.podman.nix
+++ b/testdata/TestBuildSpec_BuildEnabled.podman.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib, ... }:
+{ pkgs, lib, config, ... }:
 
 {
   # Runtime
@@ -6,15 +6,14 @@
     enable = true;
     autoPrune.enable = true;
     dockerCompat = true;
-    defaultNetwork.settings = {
-      # Required for container networking to be able to use names.
-      dns_enabled = true;
-    };
   };
 
-  # Enable container name DNS for non-default Podman networks.
-  # https://github.com/NixOS/nixpkgs/issues/226365
-  networking.firewall.interfaces."podman+".allowedUDPPorts = [ 53 ];
+  # Enable container name DNS for all Podman networks.
+  networking.firewall.interfaces = let
+    matchAll = if !config.networking.nftables.enable then "podman+" else "podman*";
+  in {
+    "${matchAll}".allowedUDPPorts = [ 53 ];
+  };
 
   virtualisation.oci-containers.backend = "podman";
 

--- a/testdata/TestCommandAndEntrypoint.podman.nix
+++ b/testdata/TestCommandAndEntrypoint.podman.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib, ... }:
+{ pkgs, lib, config, ... }:
 
 {
   # Runtime
@@ -6,15 +6,14 @@
     enable = true;
     autoPrune.enable = true;
     dockerCompat = true;
-    defaultNetwork.settings = {
-      # Required for container networking to be able to use names.
-      dns_enabled = true;
-    };
   };
 
-  # Enable container name DNS for non-default Podman networks.
-  # https://github.com/NixOS/nixpkgs/issues/226365
-  networking.firewall.interfaces."podman+".allowedUDPPorts = [ 53 ];
+  # Enable container name DNS for all Podman networks.
+  networking.firewall.interfaces = let
+    matchAll = if !config.networking.nftables.enable then "podman+" else "podman*";
+  in {
+    "${matchAll}".allowedUDPPorts = [ 53 ];
+  };
 
   virtualisation.oci-containers.backend = "podman";
 

--- a/testdata/TestComposeEnvFiles.podman.nix
+++ b/testdata/TestComposeEnvFiles.podman.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib, ... }:
+{ pkgs, lib, config, ... }:
 
 {
   # Runtime
@@ -6,15 +6,14 @@
     enable = true;
     autoPrune.enable = true;
     dockerCompat = true;
-    defaultNetwork.settings = {
-      # Required for container networking to be able to use names.
-      dns_enabled = true;
-    };
   };
 
-  # Enable container name DNS for non-default Podman networks.
-  # https://github.com/NixOS/nixpkgs/issues/226365
-  networking.firewall.interfaces."podman+".allowedUDPPorts = [ 53 ];
+  # Enable container name DNS for all Podman networks.
+  networking.firewall.interfaces = let
+    matchAll = if !config.networking.nftables.enable then "podman+" else "podman*";
+  in {
+    "${matchAll}".allowedUDPPorts = [ 53 ];
+  };
 
   virtualisation.oci-containers.backend = "podman";
 

--- a/testdata/TestDeployDevices.podman.nix
+++ b/testdata/TestDeployDevices.podman.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib, ... }:
+{ pkgs, lib, config, ... }:
 
 {
   # Runtime
@@ -6,15 +6,14 @@
     enable = true;
     autoPrune.enable = true;
     dockerCompat = true;
-    defaultNetwork.settings = {
-      # Required for container networking to be able to use names.
-      dns_enabled = true;
-    };
   };
 
-  # Enable container name DNS for non-default Podman networks.
-  # https://github.com/NixOS/nixpkgs/issues/226365
-  networking.firewall.interfaces."podman+".allowedUDPPorts = [ 53 ];
+  # Enable container name DNS for all Podman networks.
+  networking.firewall.interfaces = let
+    matchAll = if !config.networking.nftables.enable then "podman+" else "podman*";
+  in {
+    "${matchAll}".allowedUDPPorts = [ 53 ];
+  };
 
   virtualisation.oci-containers.backend = "podman";
 

--- a/testdata/TestEmptyEnv.podman.nix
+++ b/testdata/TestEmptyEnv.podman.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib, ... }:
+{ pkgs, lib, config, ... }:
 
 {
   # Runtime
@@ -6,15 +6,14 @@
     enable = true;
     autoPrune.enable = true;
     dockerCompat = true;
-    defaultNetwork.settings = {
-      # Required for container networking to be able to use names.
-      dns_enabled = true;
-    };
   };
 
-  # Enable container name DNS for non-default Podman networks.
-  # https://github.com/NixOS/nixpkgs/issues/226365
-  networking.firewall.interfaces."podman+".allowedUDPPorts = [ 53 ];
+  # Enable container name DNS for all Podman networks.
+  networking.firewall.interfaces = let
+    matchAll = if !config.networking.nftables.enable then "podman+" else "podman*";
+  in {
+    "${matchAll}".allowedUDPPorts = [ 53 ];
+  };
 
   virtualisation.oci-containers.backend = "podman";
 

--- a/testdata/TestEnvFiles.podman.nix
+++ b/testdata/TestEnvFiles.podman.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib, ... }:
+{ pkgs, lib, config, ... }:
 
 {
   # Runtime
@@ -6,15 +6,14 @@
     enable = true;
     autoPrune.enable = true;
     dockerCompat = true;
-    defaultNetwork.settings = {
-      # Required for container networking to be able to use names.
-      dns_enabled = true;
-    };
   };
 
-  # Enable container name DNS for non-default Podman networks.
-  # https://github.com/NixOS/nixpkgs/issues/226365
-  networking.firewall.interfaces."podman+".allowedUDPPorts = [ 53 ];
+  # Enable container name DNS for all Podman networks.
+  networking.firewall.interfaces = let
+    matchAll = if !config.networking.nftables.enable then "podman+" else "podman*";
+  in {
+    "${matchAll}".allowedUDPPorts = [ 53 ];
+  };
 
   virtualisation.oci-containers.backend = "podman";
 

--- a/testdata/TestEnvFilesOnly.podman.nix
+++ b/testdata/TestEnvFilesOnly.podman.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib, ... }:
+{ pkgs, lib, config, ... }:
 
 {
   # Runtime
@@ -6,15 +6,14 @@
     enable = true;
     autoPrune.enable = true;
     dockerCompat = true;
-    defaultNetwork.settings = {
-      # Required for container networking to be able to use names.
-      dns_enabled = true;
-    };
   };
 
-  # Enable container name DNS for non-default Podman networks.
-  # https://github.com/NixOS/nixpkgs/issues/226365
-  networking.firewall.interfaces."podman+".allowedUDPPorts = [ 53 ];
+  # Enable container name DNS for all Podman networks.
+  networking.firewall.interfaces = let
+    matchAll = if !config.networking.nftables.enable then "podman+" else "podman*";
+  in {
+    "${matchAll}".allowedUDPPorts = [ 53 ];
+  };
 
   virtualisation.oci-containers.backend = "podman";
 

--- a/testdata/TestEscapeChars.podman.nix
+++ b/testdata/TestEscapeChars.podman.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib, ... }:
+{ pkgs, lib, config, ... }:
 
 {
   # Runtime
@@ -6,15 +6,14 @@
     enable = true;
     autoPrune.enable = true;
     dockerCompat = true;
-    defaultNetwork.settings = {
-      # Required for container networking to be able to use names.
-      dns_enabled = true;
-    };
   };
 
-  # Enable container name DNS for non-default Podman networks.
-  # https://github.com/NixOS/nixpkgs/issues/226365
-  networking.firewall.interfaces."podman+".allowedUDPPorts = [ 53 ];
+  # Enable container name DNS for all Podman networks.
+  networking.firewall.interfaces = let
+    matchAll = if !config.networking.nftables.enable then "podman+" else "podman*";
+  in {
+    "${matchAll}".allowedUDPPorts = [ 53 ];
+  };
 
   virtualisation.oci-containers.backend = "podman";
 

--- a/testdata/TestExternalNetworksAndVolumes.podman.nix
+++ b/testdata/TestExternalNetworksAndVolumes.podman.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib, ... }:
+{ pkgs, lib, config, ... }:
 
 {
   # Runtime
@@ -6,15 +6,14 @@
     enable = true;
     autoPrune.enable = true;
     dockerCompat = true;
-    defaultNetwork.settings = {
-      # Required for container networking to be able to use names.
-      dns_enabled = true;
-    };
   };
 
-  # Enable container name DNS for non-default Podman networks.
-  # https://github.com/NixOS/nixpkgs/issues/226365
-  networking.firewall.interfaces."podman+".allowedUDPPorts = [ 53 ];
+  # Enable container name DNS for all Podman networks.
+  networking.firewall.interfaces = let
+    matchAll = if !config.networking.nftables.enable then "podman+" else "podman*";
+  in {
+    "${matchAll}".allowedUDPPorts = [ 53 ];
+  };
 
   virtualisation.oci-containers.backend = "podman";
 

--- a/testdata/TestMacvlanSupport.podman.nix
+++ b/testdata/TestMacvlanSupport.podman.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib, ... }:
+{ pkgs, lib, config, ... }:
 
 {
   # Runtime
@@ -6,15 +6,14 @@
     enable = true;
     autoPrune.enable = true;
     dockerCompat = true;
-    defaultNetwork.settings = {
-      # Required for container networking to be able to use names.
-      dns_enabled = true;
-    };
   };
 
-  # Enable container name DNS for non-default Podman networks.
-  # https://github.com/NixOS/nixpkgs/issues/226365
-  networking.firewall.interfaces."podman+".allowedUDPPorts = [ 53 ];
+  # Enable container name DNS for all Podman networks.
+  networking.firewall.interfaces = let
+    matchAll = if !config.networking.nftables.enable then "podman+" else "podman*";
+  in {
+    "${matchAll}".allowedUDPPorts = [ 53 ];
+  };
 
   virtualisation.oci-containers.backend = "podman";
 

--- a/testdata/TestMultipleNetworks.podman.nix
+++ b/testdata/TestMultipleNetworks.podman.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib, ... }:
+{ pkgs, lib, config, ... }:
 
 {
   # Runtime
@@ -6,15 +6,14 @@
     enable = true;
     autoPrune.enable = true;
     dockerCompat = true;
-    defaultNetwork.settings = {
-      # Required for container networking to be able to use names.
-      dns_enabled = true;
-    };
   };
 
-  # Enable container name DNS for non-default Podman networks.
-  # https://github.com/NixOS/nixpkgs/issues/226365
-  networking.firewall.interfaces."podman+".allowedUDPPorts = [ 53 ];
+  # Enable container name DNS for all Podman networks.
+  networking.firewall.interfaces = let
+    matchAll = if !config.networking.nftables.enable then "podman+" else "podman*";
+  in {
+    "${matchAll}".allowedUDPPorts = [ 53 ];
+  };
 
   virtualisation.oci-containers.backend = "podman";
 

--- a/testdata/TestNetworkAndVolumeNames.podman.nix
+++ b/testdata/TestNetworkAndVolumeNames.podman.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib, ... }:
+{ pkgs, lib, config, ... }:
 
 {
   # Runtime
@@ -6,15 +6,14 @@
     enable = true;
     autoPrune.enable = true;
     dockerCompat = true;
-    defaultNetwork.settings = {
-      # Required for container networking to be able to use names.
-      dns_enabled = true;
-    };
   };
 
-  # Enable container name DNS for non-default Podman networks.
-  # https://github.com/NixOS/nixpkgs/issues/226365
-  networking.firewall.interfaces."podman+".allowedUDPPorts = [ 53 ];
+  # Enable container name DNS for all Podman networks.
+  networking.firewall.interfaces = let
+    matchAll = if !config.networking.nftables.enable then "podman+" else "podman*";
+  in {
+    "${matchAll}".allowedUDPPorts = [ 53 ];
+  };
 
   virtualisation.oci-containers.backend = "podman";
 

--- a/testdata/TestNetworkSettings.podman.nix
+++ b/testdata/TestNetworkSettings.podman.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib, ... }:
+{ pkgs, lib, config, ... }:
 
 {
   # Runtime
@@ -6,15 +6,14 @@
     enable = true;
     autoPrune.enable = true;
     dockerCompat = true;
-    defaultNetwork.settings = {
-      # Required for container networking to be able to use names.
-      dns_enabled = true;
-    };
   };
 
-  # Enable container name DNS for non-default Podman networks.
-  # https://github.com/NixOS/nixpkgs/issues/226365
-  networking.firewall.interfaces."podman+".allowedUDPPorts = [ 53 ];
+  # Enable container name DNS for all Podman networks.
+  networking.firewall.interfaces = let
+    matchAll = if !config.networking.nftables.enable then "podman+" else "podman*";
+  in {
+    "${matchAll}".allowedUDPPorts = [ 53 ];
+  };
 
   virtualisation.oci-containers.backend = "podman";
 

--- a/testdata/TestNoCreateRootTarget.podman.nix
+++ b/testdata/TestNoCreateRootTarget.podman.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib, ... }:
+{ pkgs, lib, config, ... }:
 
 {
   # Runtime
@@ -6,15 +6,14 @@
     enable = true;
     autoPrune.enable = true;
     dockerCompat = true;
-    defaultNetwork.settings = {
-      # Required for container networking to be able to use names.
-      dns_enabled = true;
-    };
   };
 
-  # Enable container name DNS for non-default Podman networks.
-  # https://github.com/NixOS/nixpkgs/issues/226365
-  networking.firewall.interfaces."podman+".allowedUDPPorts = [ 53 ];
+  # Enable container name DNS for all Podman networks.
+  networking.firewall.interfaces = let
+    matchAll = if !config.networking.nftables.enable then "podman+" else "podman*";
+  in {
+    "${matchAll}".allowedUDPPorts = [ 53 ];
+  };
 
   virtualisation.oci-containers.backend = "podman";
 

--- a/testdata/TestNoRestart.podman.nix
+++ b/testdata/TestNoRestart.podman.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib, ... }:
+{ pkgs, lib, config, ... }:
 
 {
   # Runtime
@@ -6,15 +6,14 @@
     enable = true;
     autoPrune.enable = true;
     dockerCompat = true;
-    defaultNetwork.settings = {
-      # Required for container networking to be able to use names.
-      dns_enabled = true;
-    };
   };
 
-  # Enable container name DNS for non-default Podman networks.
-  # https://github.com/NixOS/nixpkgs/issues/226365
-  networking.firewall.interfaces."podman+".allowedUDPPorts = [ 53 ];
+  # Enable container name DNS for all Podman networks.
+  networking.firewall.interfaces = let
+    matchAll = if !config.networking.nftables.enable then "podman+" else "podman*";
+  in {
+    "${matchAll}".allowedUDPPorts = [ 53 ];
+  };
 
   virtualisation.oci-containers.backend = "podman";
 

--- a/testdata/TestNoWriteNixSetup.podman.nix
+++ b/testdata/TestNoWriteNixSetup.podman.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib, ... }:
+{ pkgs, lib, config, ... }:
 
 {
 

--- a/testdata/TestOverrideSystemdStopTimeout.podman.nix
+++ b/testdata/TestOverrideSystemdStopTimeout.podman.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib, ... }:
+{ pkgs, lib, config, ... }:
 
 {
   # Runtime
@@ -6,15 +6,14 @@
     enable = true;
     autoPrune.enable = true;
     dockerCompat = true;
-    defaultNetwork.settings = {
-      # Required for container networking to be able to use names.
-      dns_enabled = true;
-    };
   };
 
-  # Enable container name DNS for non-default Podman networks.
-  # https://github.com/NixOS/nixpkgs/issues/226365
-  networking.firewall.interfaces."podman+".allowedUDPPorts = [ 53 ];
+  # Enable container name DNS for all Podman networks.
+  networking.firewall.interfaces = let
+    matchAll = if !config.networking.nftables.enable then "podman+" else "podman*";
+  in {
+    "${matchAll}".allowedUDPPorts = [ 53 ];
+  };
 
   virtualisation.oci-containers.backend = "podman";
 

--- a/testdata/TestProject.podman.nix
+++ b/testdata/TestProject.podman.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib, ... }:
+{ pkgs, lib, config, ... }:
 
 {
   # Runtime
@@ -6,15 +6,14 @@
     enable = true;
     autoPrune.enable = true;
     dockerCompat = true;
-    defaultNetwork.settings = {
-      # Required for container networking to be able to use names.
-      dns_enabled = true;
-    };
   };
 
-  # Enable container name DNS for non-default Podman networks.
-  # https://github.com/NixOS/nixpkgs/issues/226365
-  networking.firewall.interfaces."podman+".allowedUDPPorts = [ 53 ];
+  # Enable container name DNS for all Podman networks.
+  networking.firewall.interfaces = let
+    matchAll = if !config.networking.nftables.enable then "podman+" else "podman*";
+  in {
+    "${matchAll}".allowedUDPPorts = [ 53 ];
+  };
 
   virtualisation.oci-containers.backend = "podman";
 

--- a/testdata/TestRelativeServiceVolumes.podman.nix
+++ b/testdata/TestRelativeServiceVolumes.podman.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib, ... }:
+{ pkgs, lib, config, ... }:
 
 {
   # Runtime
@@ -6,15 +6,14 @@
     enable = true;
     autoPrune.enable = true;
     dockerCompat = true;
-    defaultNetwork.settings = {
-      # Required for container networking to be able to use names.
-      dns_enabled = true;
-    };
   };
 
-  # Enable container name DNS for non-default Podman networks.
-  # https://github.com/NixOS/nixpkgs/issues/226365
-  networking.firewall.interfaces."podman+".allowedUDPPorts = [ 53 ];
+  # Enable container name DNS for all Podman networks.
+  networking.firewall.interfaces = let
+    matchAll = if !config.networking.nftables.enable then "podman+" else "podman*";
+  in {
+    "${matchAll}".allowedUDPPorts = [ 53 ];
+  };
 
   virtualisation.oci-containers.backend = "podman";
 

--- a/testdata/TestRelativeServiceVolumes_CurrentDirectory.podman.nix
+++ b/testdata/TestRelativeServiceVolumes_CurrentDirectory.podman.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib, ... }:
+{ pkgs, lib, config, ... }:
 
 {
   # Runtime
@@ -6,15 +6,14 @@
     enable = true;
     autoPrune.enable = true;
     dockerCompat = true;
-    defaultNetwork.settings = {
-      # Required for container networking to be able to use names.
-      dns_enabled = true;
-    };
   };
 
-  # Enable container name DNS for non-default Podman networks.
-  # https://github.com/NixOS/nixpkgs/issues/226365
-  networking.firewall.interfaces."podman+".allowedUDPPorts = [ 53 ];
+  # Enable container name DNS for all Podman networks.
+  networking.firewall.interfaces = let
+    matchAll = if !config.networking.nftables.enable then "podman+" else "podman*";
+  in {
+    "${matchAll}".allowedUDPPorts = [ 53 ];
+  };
 
   virtualisation.oci-containers.backend = "podman";
 

--- a/testdata/TestRemoveVolumes.podman.nix
+++ b/testdata/TestRemoveVolumes.podman.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib, ... }:
+{ pkgs, lib, config, ... }:
 
 {
   # Runtime
@@ -6,15 +6,14 @@
     enable = true;
     autoPrune.enable = true;
     dockerCompat = true;
-    defaultNetwork.settings = {
-      # Required for container networking to be able to use names.
-      dns_enabled = true;
-    };
   };
 
-  # Enable container name DNS for non-default Podman networks.
-  # https://github.com/NixOS/nixpkgs/issues/226365
-  networking.firewall.interfaces."podman+".allowedUDPPorts = [ 53 ];
+  # Enable container name DNS for all Podman networks.
+  networking.firewall.interfaces = let
+    matchAll = if !config.networking.nftables.enable then "podman+" else "podman*";
+  in {
+    "${matchAll}".allowedUDPPorts = [ 53 ];
+  };
 
   virtualisation.oci-containers.backend = "podman";
 

--- a/testdata/TestSystemdMount.podman.nix
+++ b/testdata/TestSystemdMount.podman.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib, ... }:
+{ pkgs, lib, config, ... }:
 
 {
   # Runtime
@@ -6,15 +6,14 @@
     enable = true;
     autoPrune.enable = true;
     dockerCompat = true;
-    defaultNetwork.settings = {
-      # Required for container networking to be able to use names.
-      dns_enabled = true;
-    };
   };
 
-  # Enable container name DNS for non-default Podman networks.
-  # https://github.com/NixOS/nixpkgs/issues/226365
-  networking.firewall.interfaces."podman+".allowedUDPPorts = [ 53 ];
+  # Enable container name DNS for all Podman networks.
+  networking.firewall.interfaces = let
+    matchAll = if !config.networking.nftables.enable then "podman+" else "podman*";
+  in {
+    "${matchAll}".allowedUDPPorts = [ 53 ];
+  };
 
   virtualisation.oci-containers.backend = "podman";
 

--- a/testdata/TestUnusedResources.podman.nix
+++ b/testdata/TestUnusedResources.podman.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib, ... }:
+{ pkgs, lib, config, ... }:
 
 {
   # Runtime
@@ -6,15 +6,14 @@
     enable = true;
     autoPrune.enable = true;
     dockerCompat = true;
-    defaultNetwork.settings = {
-      # Required for container networking to be able to use names.
-      dns_enabled = true;
-    };
   };
 
-  # Enable container name DNS for non-default Podman networks.
-  # https://github.com/NixOS/nixpkgs/issues/226365
-  networking.firewall.interfaces."podman+".allowedUDPPorts = [ 53 ];
+  # Enable container name DNS for all Podman networks.
+  networking.firewall.interfaces = let
+    matchAll = if !config.networking.nftables.enable then "podman+" else "podman*";
+  in {
+    "${matchAll}".allowedUDPPorts = [ 53 ];
+  };
 
   virtualisation.oci-containers.backend = "podman";
 

--- a/testdata/TestUpheldBy.podman.nix
+++ b/testdata/TestUpheldBy.podman.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib, ... }:
+{ pkgs, lib, config, ... }:
 
 {
   # Runtime
@@ -6,15 +6,14 @@
     enable = true;
     autoPrune.enable = true;
     dockerCompat = true;
-    defaultNetwork.settings = {
-      # Required for container networking to be able to use names.
-      dns_enabled = true;
-    };
   };
 
-  # Enable container name DNS for non-default Podman networks.
-  # https://github.com/NixOS/nixpkgs/issues/226365
-  networking.firewall.interfaces."podman+".allowedUDPPorts = [ 53 ];
+  # Enable container name DNS for all Podman networks.
+  networking.firewall.interfaces = let
+    matchAll = if !config.networking.nftables.enable then "podman+" else "podman*";
+  in {
+    "${matchAll}".allowedUDPPorts = [ 53 ];
+  };
 
   virtualisation.oci-containers.backend = "podman";
 


### PR DESCRIPTION
Idea is to support both iptables (default) and nftables for Podman DNS config. See: https://github.com/NixOS/nixpkgs/issues/226365#issuecomment-2570032922

Docker always uses iptables, and handles configuring firewall rules itself. See:

* https://github.com/NixOS/nixpkgs/issues/111852
* Comment here on nftables + Docker: https://github.com/NixOS/nixpkgs/blob/f6687779bf4c396250831aa5a32cbfeb85bb07a3/nixos/modules/services/networking/nftables.nix#L61 

As part of this PR, I have also cleaned up the redundant Podman DNS config for the default network. `compose2nix` does not use the default network at all, and anyways configures a firewall rule that also covers the default network (`podman0` interface).

Closes #74 