### PR TITLE
add compose-containers module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,47 @@
+# compose2nix module
+
+NixOS module that uses compose2nix to convert docker compose files to nix
+
+## Module
+
+### Installation (Flakes)
+
+Add `compose2nix.nixosModules.compose-containers` module to your system
+
+```
+{
+  inputs.compose2nix.url = "github:aksiksi/compose2nix/549403c432e5058f6800e6208f5a7d1f071f1338";
+
+  outputs = { self, nixpkgs, compose2nix }: {
+    nixosConfigurations."yourhostname" = nixpkgs.lib.nixosSystem {
+      system = "x86_64-linux";
+      modules = [
+        compose2nix.nixosModules.compose-containers
+        ./configuration.nix
+      ];
+    };
+  };
+}
+```
+
+### Usage
+
+Use module by specifying `virtualisation.oci-containers.compose-containers.<name>`
+
+Specify the location of the docker compose file in the `path` attribute
+
+You can also specify options for the compose2nix command in the `convertOptions` attribute
+
+An example:
+
+```
+{ pkgs, config, ... }:
+{
+  virtualisation.oci-containers.compose-containers."myservice" = {
+    path = ./myservice/docker-compose.yml;
+    convertOptions = {
+      default_stop_timeout = "5m";
+    };
+  };
+}
+```

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,7 @@
+{
+  inputs = {};
+
+  outputs = { ... }: {
+    nixosModules.compose-containers = import ./modules/compose-containers.nix;
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,13 @@
 {
-  inputs = {};
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
 
-  outputs = { ... }: {
-    nixosModules.compose-containers = import ./modules/compose-containers.nix;
+  outputs = { self, nixpkgs, ... }: {
+    nixosModules.compose-containers = { pkgs, config, lib, ... } @ args: let
+      inputs = { inherit nixpkgs; compose2nix = self; };
+      args' = args // { inherit inputs; };
+      module = import ./modules/compose-containers.nix;
+    in module args';
   };
 }

--- a/modules/compose-containers.nix
+++ b/modules/compose-containers.nix
@@ -1,0 +1,57 @@
+{ pkgs, config, lib, ... } @ args:
+with lib; let
+  importCompose = { name, path, convertOptions ? {} }: let
+    options = convertOptions // {
+      runtime = config.virtualisation.oci-containers.backend;
+      write_nix_setup = false;
+      project = name;
+      inputs = path;
+    };
+    asValue = v: with builtins; if isBool v then toJSON v
+      else if isInt v || isFloat v then toString v else v;
+    asArg = { name, value }: "-${name}=${asValue value}";
+    asArgs = options: map asArg (attrsToList options);
+    drv = derivation {
+      name = "${name}-compose.nix";
+      system = pkgs.system;
+      builder = "${pkgs.bash}/bin/bash";
+      args = [ "-c" ''
+        exec ${pkgs.compose2nix}/bin/compose2nix "$@" -output="$out"
+      '' "_" ] ++ (asArgs options);
+    };
+  in import drv;
+  cfg = config.virtualisation.oci-containers;
+  mkModule = { name, value }: (importCompose ({ inherit name; } // value));
+  modules = map mkModule (attrsToList cfg.compose-containers);
+  configs = map (m: m args) modules;
+  passConfigs = paths: let
+    singlePass = l: setAttrByPath l (mkMerge (map (c: attrByPath l {} c) configs));
+    lists = map (strings.splitString ".") paths;
+  in mergeAttrsList (map singlePass lists);
+in {
+  options.virtualisation.oci-containers.compose-containers = mkOption {
+    default = { };
+    type = types.attrsOf (types.submodule ({ name, ... }: {
+      options = {
+        path = mkOption {
+          type = with types; path;
+          description = "Path to compose file.";
+        };
+        convertOptions = mkOption {
+          type = with types; attrsOf (oneOf [ str int float bool ]);
+          default = { };
+          example = {
+            default_stop_timeout = "1m";
+          };
+          description = "Options for {command}`compose2nix`.";
+        };
+      };
+    }));
+    description = "OCI (Docker) compose containers to run as systemd services.";
+  };
+
+  config = passConfigs [
+    "virtualisation.oci-containers.containers"
+    "systemd"
+  ];
+}


### PR DESCRIPTION
Adding `compose-containers` module, that allows to load docker-compose.**yml** files right on the NixOS configuration stage.
Check out changes in readme to see an example of use.