### PR TITLE
fix: translate multi-element entrypoint to Docker semantics

### DIFF
--- a/compose.go
+++ b/compose.go
@@ -495,7 +495,21 @@ func (g *Generator) buildNixContainer(service types.ServiceConfig, networkMap ma
 		c.Command = service.Command
 	}
 	if entrypoint := service.Entrypoint; !entrypoint.IsZero() {
-		c.ExtraOptions = append(c.ExtraOptions, fmt.Sprintf("--entrypoint=%s", sliceToStringArray(entrypoint)))
+		// Docker's --entrypoint flag only accepts a single argument (the
+		// executable). When Compose specifies a multi-element entrypoint, the
+		// first element is the entrypoint and the remaining elements are
+		// prepended to the command. An explicitly empty entrypoint ([]) clears
+		// the image's entrypoint, which maps to an empty --entrypoint value.
+		//
+		// See: https://github.com/aksiksi/compose2nix/issues/120
+		if len(entrypoint) == 0 {
+			c.ExtraOptions = append(c.ExtraOptions, "--entrypoint=")
+		} else {
+			c.ExtraOptions = append(c.ExtraOptions, fmt.Sprintf("--entrypoint=%s", entrypoint[0]))
+			if len(entrypoint) > 1 {
+				c.Command = append(append([]string{}, entrypoint[1:]...), c.Command...)
+			}
+		}
 	}
 
 	// Figure out explicit dependencies for this container.

--- a/testdata/TestCommandAndEntrypoint.docker.nix
+++ b/testdata/TestCommandAndEntrypoint.docker.nix
@@ -13,11 +13,11 @@
   # Containers
   virtualisation.oci-containers.containers."test-both" = {
     image = "nginx:latest";
-    cmd = [ "ls" "-la" "\"escape me please\"" ];
+    cmd = [ "-g" "daemon off;" "-c" "/etc/config/nginx/conf/nginx.conf" "ls" "-la" "\"escape me please\"" ];
     log-driver = "journald";
     autoStart = false;
     extraOptions = [
-      "--entrypoint=[\"nginx\", \"-g\", \"daemon off;\", \"-c\", \"/etc/config/nginx/conf/nginx.conf\"]"
+      "--entrypoint=nginx"
       "--network-alias=both"
       "--network=test_default"
     ];
@@ -39,7 +39,7 @@
     log-driver = "journald";
     autoStart = false;
     extraOptions = [
-      "--entrypoint=[]"
+      "--entrypoint="
       "--network-alias=empty-command-and-entrypoint"
       "--network=test_default"
     ];
@@ -77,10 +77,11 @@
   };
   virtualisation.oci-containers.containers."test-string" = {
     image = "nginx:latest";
+    cmd = [ "bash" "/abc.sh" ];
     log-driver = "journald";
     autoStart = false;
     extraOptions = [
-      "--entrypoint=[\"ENV_VAR=\${ABC}\", \"bash\", \"/abc.sh\"]"
+      "--entrypoint=ENV_VAR=\${ABC}"
       "--network-alias=string"
       "--network=test_default"
     ];

--- a/testdata/TestCommandAndEntrypoint.podman.nix
+++ b/testdata/TestCommandAndEntrypoint.podman.nix
@@ -22,11 +22,11 @@
   # Containers
   virtualisation.oci-containers.containers."test-both" = {
     image = "nginx:latest";
-    cmd = [ "ls" "-la" "\"escape me please\"" ];
+    cmd = [ "-g" "daemon off;" "-c" "/etc/config/nginx/conf/nginx.conf" "ls" "-la" "\"escape me please\"" ];
     log-driver = "journald";
     autoStart = false;
     extraOptions = [
-      "--entrypoint=[\"nginx\", \"-g\", \"daemon off;\", \"-c\", \"/etc/config/nginx/conf/nginx.conf\"]"
+      "--entrypoint=nginx"
       "--network-alias=both"
       "--network=test_default"
     ];
@@ -48,7 +48,7 @@
     log-driver = "journald";
     autoStart = false;
     extraOptions = [
-      "--entrypoint=[]"
+      "--entrypoint="
       "--network-alias=empty-command-and-entrypoint"
       "--network=test_default"
     ];
@@ -86,10 +86,11 @@
   };
   virtualisation.oci-containers.containers."test-string" = {
     image = "nginx:latest";
+    cmd = [ "bash" "/abc.sh" ];
     log-driver = "journald";
     autoStart = false;
     extraOptions = [
-      "--entrypoint=[\"ENV_VAR=\${ABC}\", \"bash\", \"/abc.sh\"]"
+      "--entrypoint=ENV_VAR=\${ABC}"
       "--network-alias=string"
       "--network=test_default"
     ];


### PR DESCRIPTION
## Problem

When a service specifies a multi-element `entrypoint` (list form like `["/bin/sh", "-c", "..."] `or a shell string that parses to multiple tokens), compose2nix serialized the entire parsed entrypoint slice into a JSON-array-looking string and passed it as a single `--entrypoint` value:

```
--entrypoint=["/bin/sh", "-c", " apt-get update && ... "]
```

Docker's (and podman's) `--entrypoint` flag accepts only **one** argument (the executable). Passing a bracketed array literal is not valid, so containers with a multi-element entrypoint fail to run.

## Fix

Translate `entrypoint` the way `docker run --entrypoint` actually behaves:
- **Multi-element entrypoint:** first element → `--entrypoint=<exe>`; remaining elements are **prepended to the container command** (`cmd`).
- **Single-element entrypoint:** `--entrypoint=<exe>` (no array wrapping).
- **Explicitly empty entrypoint (`[]`):** `--entrypoint=` — clears the image's entrypoint.
- **Unset/null entrypoint:** unchanged (skipped).

Golden test fixtures updated using the project's own `go test -update` mechanism.

## Test results

```
go build ./...   → OK
go vet ./...     → OK (clean)
gofmt compose.go → (no output — clean)
go test ./...    → ok github.com/aksiksi/compose2nix 2.134s (127/127 PASS)
```

Fixes #120